### PR TITLE
Add order authorization to prevent unauthorized access

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -13,6 +13,8 @@ class OrdersController < ApplicationController
   private
 
   def set_order
-    @order = Order.includes(order_items: :product_variant).find(params[:id])
+    @order = Current.user.orders.includes(order_items: :product_variant).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to orders_path, alert: "Order not found"
   end
 end

--- a/specs/009-order-user-association/checklists/requirements.md
+++ b/specs/009-order-user-association/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Order User Association
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Existing codebase analysis confirms database associations already exist (`Order belongs_to :user, optional: true` and `User has_many :orders`)
+- Key gap identified: Order show action lacks user authorization check (security concern to address in implementation)

--- a/specs/009-order-user-association/data-model.md
+++ b/specs/009-order-user-association/data-model.md
@@ -1,0 +1,123 @@
+# Data Model: Order User Association
+
+**Feature**: 009-order-user-association
+**Date**: 2025-11-26
+
+## Summary
+
+No database schema changes required. This document describes the existing data model that supports order-user association.
+
+## Existing Entities
+
+### User
+
+**Table**: `users`
+**Model**: `app/models/user.rb`
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | bigint | PK, auto | Primary key |
+| email_address | string | NOT NULL, UNIQUE | User's email |
+| password_digest | string | NOT NULL | Bcrypt password hash |
+| organization_id | bigint | FK, NULL | Optional organization membership |
+| role | enum | NULL | owner/admin/member (for org users) |
+| created_at | datetime | NOT NULL | Record creation |
+| updated_at | datetime | NOT NULL | Last update |
+
+**Associations**:
+```ruby
+has_many :orders, dependent: :destroy
+has_many :sessions, dependent: :destroy
+has_many :carts, dependent: :destroy
+belongs_to :organization, optional: true
+```
+
+---
+
+### Order
+
+**Table**: `orders`
+**Model**: `app/models/order.rb`
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | bigint | PK, auto | Primary key |
+| user_id | bigint | FK, NULL | **Order owner (key field)** |
+| organization_id | bigint | FK, NULL | For B2B orders |
+| placed_by_user_id | bigint | FK, NULL | User who placed B2B order |
+| email | string | NOT NULL | Customer email |
+| order_number | string | NOT NULL, UNIQUE | Display number (ORD-YYYY-NNNNNN) |
+| stripe_session_id | string | NOT NULL, UNIQUE | Stripe checkout session |
+| status | enum | NOT NULL | pending/paid/processing/shipped/delivered/cancelled/refunded |
+| subtotal_amount | decimal | NOT NULL, >= 0 | Pre-tax subtotal |
+| vat_amount | decimal | NOT NULL, >= 0 | VAT at 20% |
+| shipping_amount | decimal | NOT NULL, >= 0 | Shipping cost |
+| total_amount | decimal | NOT NULL, >= 0 | Final total |
+| shipping_* | various | NOT NULL | Shipping address fields |
+| created_at | datetime | NOT NULL | Order placement time |
+| updated_at | datetime | NOT NULL | Last update |
+
+**Key Association for This Feature**:
+```ruby
+belongs_to :user, optional: true  # NULL for guest orders
+```
+
+**Why `optional: true`**:
+- Enables guest checkout (orders without user accounts)
+- User can complete purchase without creating account
+- Order is still valid and processed normally
+
+---
+
+## Entity Relationship Diagram
+
+```
+┌─────────────────────┐
+│       User          │
+├─────────────────────┤
+│ id (PK)             │
+│ email_address       │
+│ ...                 │
+└─────────┬───────────┘
+          │
+          │ 1:N (optional)
+          │
+          ▼
+┌─────────────────────┐
+│       Order         │
+├─────────────────────┤
+│ id (PK)             │
+│ user_id (FK, NULL)  │◄─── KEY RELATIONSHIP
+│ order_number        │
+│ status              │
+│ total_amount        │
+│ ...                 │
+└─────────────────────┘
+```
+
+## Authorization Logic
+
+**Query Pattern for Authorized Access**:
+
+```ruby
+# Scoped lookup - only returns user's own orders
+Current.user.orders.find(params[:id])
+
+# Equivalent SQL:
+# SELECT * FROM orders WHERE user_id = ? AND id = ?
+```
+
+**Why This Works**:
+- `Current.user.orders` returns only orders belonging to current user
+- `find(id)` within that scope ensures order belongs to user
+- Raises `ActiveRecord::RecordNotFound` if order doesn't exist or belongs to another user
+- No way to access orders with different `user_id` or `user_id = NULL`
+
+## No Schema Migrations Required
+
+The existing schema fully supports this feature:
+- `user_id` column exists on `orders` table
+- Foreign key relationship established
+- Association configured in both models
+
+All changes are controller/view level only.

--- a/specs/009-order-user-association/plan.md
+++ b/specs/009-order-user-association/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Order User Association
+
+**Branch**: `009-order-user-association` | **Date**: 2025-11-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/009-order-user-association/spec.md`
+
+## Summary
+
+Implement authorization controls for order viewing to ensure users can only access their own orders. The order-user association at checkout and order history listing already exist - this feature focuses on adding the missing authorization layer to prevent unauthorized access to order details.
+
+**Key Gap Identified**: The `OrdersController#show` action currently allows any authenticated user to view any order by ID - a security vulnerability that must be fixed.
+
+## Technical Context
+
+**Language/Version**: Ruby 3.3.0+ / Rails 8.x
+**Primary Dependencies**: Rails 8 (ActiveRecord, ActionController), Hotwire (Turbo + Stimulus)
+**Storage**: PostgreSQL 14+ (existing `orders` table with `user_id` column)
+**Testing**: Rails Minitest (models, controllers, integration, system tests)
+**Target Platform**: Web application (Linux server production, macOS development)
+**Project Type**: Web (Rails monolith with Vite frontend)
+**Performance Goals**: Order history page loads within 2 seconds (SC-002)
+**Constraints**: Must maintain guest checkout functionality (orders without user association)
+**Scale/Scope**: Standard e-commerce order volumes
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Test-First Development | ✅ PASS | Tests will be written first for authorization logic |
+| II. SEO & Structured Data | ✅ N/A | Order pages are authenticated, not public/indexable |
+| III. Performance & Scalability | ✅ PASS | Uses existing eager loading; no N+1 queries introduced |
+| IV. Security & Payment Integrity | ✅ PASS | This feature FIXES a security gap (unauthorized order access) |
+| V. Code Quality & Maintainability | ✅ PASS | Simple authorization pattern, RuboCop compliant |
+
+**Technology Constraints Check**:
+- ✅ No client-side state management (uses Hotwire patterns)
+- ✅ No GraphQL (REST/Rails conventions)
+- ✅ Backend rendering for order pages
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-order-user-association/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - no new API endpoints)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+app/
+├── controllers/
+│   └── orders_controller.rb    # Add authorization to show action
+├── models/
+│   └── order.rb                # Existing (no changes needed)
+└── views/
+    └── orders/
+        ├── index.html.erb      # Existing (already has empty state)
+        └── show.html.erb       # Existing (no changes needed)
+
+test/
+├── controllers/
+│   └── orders_controller_test.rb    # Add authorization tests
+├── integration/
+│   └── order_authorization_test.rb  # New integration tests
+└── system/
+    └── order_history_test.rb        # New system tests
+```
+
+**Structure Decision**: Uses existing Rails conventions. No new directories or architectural changes required.
+
+## Complexity Tracking
+
+> No violations - feature is straightforward authorization implementation.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |
+
+## Implementation Analysis
+
+### Current State (from codebase analysis)
+
+1. **Order-User Association** ✅ ALREADY WORKS
+   - `Order belongs_to :user, optional: true` (app/models/order.rb:2)
+   - `User has_many :orders` (app/models/user.rb:10)
+   - Checkout passes `client_reference_id` to Stripe (checkouts_controller.rb:54)
+   - Order creation uses user from Stripe session (checkouts_controller.rb:150-154)
+
+2. **Order Index** ✅ ALREADY WORKS
+   - Scoped to current user: `Current.user.orders.recent` (orders_controller.rb:10)
+   - Empty state handling exists in view (orders/index.html.erb:78-89)
+
+3. **Order Show** ❌ SECURITY GAP
+   - Fetches ANY order by ID: `Order.find(params[:id])` (orders_controller.rb:16)
+   - No authorization check - any logged-in user can view any order
+   - This violates FR-003 and creates a security vulnerability
+
+### Required Changes
+
+1. **Add authorization to `set_order`** in OrdersController
+   - Scope order lookup to current user's orders
+   - Handle unauthorized access gracefully (redirect with message)
+
+2. **Add tests** for authorization scenarios
+   - User viewing own order (allowed)
+   - User viewing another user's order (denied)
+   - Guest user viewing order page (redirected to login)
+   - Guest orders (orders without user_id) - determine access policy
+
+### Design Decision: Guest Order Access
+
+Guest orders (orders with `user_id: nil`) need a policy decision:
+
+**Option A**: Only accessible via order confirmation page (current behavior after checkout)
+- Guest orders cannot be viewed later (no account to log into)
+- Simple to implement - no special handling needed
+
+**Option B**: Allow access via order number + email verification
+- More user-friendly but adds complexity
+- Out of scope per spec assumptions
+
+**Decision**: Option A - Guest orders remain view-only at checkout confirmation. This aligns with the spec's assumption that "Guest checkout functionality should continue to work" without requiring new features.

--- a/specs/009-order-user-association/quickstart.md
+++ b/specs/009-order-user-association/quickstart.md
@@ -1,0 +1,124 @@
+# Quickstart: Order User Association
+
+**Feature**: 009-order-user-association
+**Date**: 2025-11-26
+
+## Overview
+
+This feature fixes a security vulnerability where any authenticated user can view any order. The fix is minimal - just authorization logic in the controller.
+
+## What's Already Done (No Changes Needed)
+
+1. **Database association**: `Order belongs_to :user, optional: true` ✅
+2. **Checkout association**: Orders linked to logged-in users at payment ✅
+3. **Order index**: Already scoped to `Current.user.orders` ✅
+4. **Views**: Order list and detail views exist with empty state ✅
+
+## What Needs Implementation
+
+### Single Change: Authorization in OrdersController
+
+**File**: `app/controllers/orders_controller.rb`
+
+**Current (vulnerable)**:
+```ruby
+def set_order
+  @order = Order.includes(order_items: :product_variant).find(params[:id])
+end
+```
+
+**Required (secure)**:
+```ruby
+def set_order
+  @order = Current.user.orders.includes(order_items: :product_variant).find(params[:id])
+rescue ActiveRecord::RecordNotFound
+  redirect_to orders_path, alert: "Order not found"
+end
+```
+
+## TDD Implementation Order
+
+Per constitution requirements, write tests FIRST:
+
+### Step 1: Write Failing Tests
+
+```ruby
+# test/controllers/orders_controller_test.rb
+
+test "show redirects when accessing another user's order" do
+  other_user = users(:other)
+  other_order = orders(:other_user_order)
+
+  sign_in users(:customer)
+  get order_path(other_order)
+
+  assert_redirected_to orders_path
+  assert_equal "Order not found", flash[:alert]
+end
+
+test "show displays own order" do
+  user = users(:customer)
+  order = orders(:customer_order)
+
+  sign_in user
+  get order_path(order)
+
+  assert_response :success
+end
+```
+
+### Step 2: Run Tests (Should Fail)
+
+```bash
+rails test test/controllers/orders_controller_test.rb
+```
+
+### Step 3: Implement Fix
+
+Update `set_order` method as shown above.
+
+### Step 4: Run Tests (Should Pass)
+
+```bash
+rails test test/controllers/orders_controller_test.rb
+```
+
+### Step 5: Run Full Test Suite + Linter
+
+```bash
+rails test
+rubocop
+brakeman
+```
+
+## Verification Checklist
+
+- [ ] Tests written before implementation
+- [ ] Tests fail initially (red phase)
+- [ ] Implementation makes tests pass (green phase)
+- [ ] All existing tests still pass
+- [ ] RuboCop passes
+- [ ] Brakeman security scan passes
+- [ ] Manual verification: Cannot access other user's order
+- [ ] Manual verification: Can access own orders
+
+## Routes Reference
+
+```
+GET /orders         -> OrdersController#index   (order list)
+GET /orders/:id     -> OrdersController#show    (order details)
+```
+
+## Test Fixtures Needed
+
+Ensure test fixtures include:
+- User with orders (`users(:customer)`, `orders(:customer_order)`)
+- Different user with orders (`users(:other)`, `orders(:other_user_order)`)
+- Guest order (order with `user_id: nil`) for edge case testing
+
+## Time Estimate
+
+- Tests: ~30 minutes
+- Implementation: ~15 minutes
+- Verification: ~15 minutes
+- **Total: ~1 hour**

--- a/specs/009-order-user-association/research.md
+++ b/specs/009-order-user-association/research.md
@@ -1,0 +1,138 @@
+# Research: Order User Association
+
+**Feature**: 009-order-user-association
+**Date**: 2025-11-26
+
+## Executive Summary
+
+Codebase analysis reveals that most of the order-user association functionality already exists. The primary gap is a **security vulnerability** in the order show action that allows any authenticated user to view any order.
+
+## Research Findings
+
+### 1. Order-User Database Association
+
+**Status**: ✅ Already Implemented
+
+**Evidence**:
+- `app/models/order.rb:2` - `belongs_to :user, optional: true`
+- `app/models/user.rb:10` - `has_many :orders, dependent: :destroy`
+- Database column `user_id` exists on orders table
+
+**Decision**: No database changes required.
+**Rationale**: The association is properly configured as optional to support guest checkout.
+
+---
+
+### 2. Order Association at Checkout
+
+**Status**: ✅ Already Implemented
+
+**Evidence**:
+- `app/controllers/checkouts_controller.rb:52-55` - Passes `client_reference_id: Current.user.id` to Stripe for logged-in users
+- `app/controllers/checkouts_controller.rb:150` - Retrieves user from `stripe_session.client_reference_id`
+- `app/controllers/checkouts_controller.rb:153-154` - Creates order with `user: user`
+
+**Decision**: No changes required to checkout flow.
+**Rationale**: The existing implementation correctly associates orders with logged-in users while supporting guest checkout.
+
+---
+
+### 3. Order History (Index)
+
+**Status**: ✅ Already Implemented
+
+**Evidence**:
+- `app/controllers/orders_controller.rb:10` - `@orders = Current.user.orders.recent.includes(:order_items, :products)`
+- `app/views/orders/index.html.erb:78-89` - Empty state handling exists
+
+**Decision**: No changes required.
+**Rationale**: Index already scopes to current user and handles empty state.
+
+---
+
+### 4. Order Show Authorization
+
+**Status**: ❌ SECURITY VULNERABILITY
+
+**Evidence**:
+- `app/controllers/orders_controller.rb:16` - `@order = Order.includes(order_items: :product_variant).find(params[:id])`
+- No authorization check - fetches ANY order by ID
+- Any authenticated user can view any order by guessing/incrementing IDs
+
+**Decision**: Fix by scoping order lookup to current user's orders.
+**Rationale**: This is a data exposure vulnerability that violates FR-003 (restrict order viewing to owner).
+
+**Alternatives Considered**:
+
+| Approach | Pros | Cons | Decision |
+|----------|------|------|----------|
+| Scope to `Current.user.orders.find(id)` | Simple, uses Rails conventions | Raises RecordNotFound for unauthorized access | ✅ Selected |
+| Manual check after fetch | Can provide custom error message | More code, potential timing attack | Rejected |
+| Pundit/CanCanCan authorization gem | Standard pattern | Overkill for single use case | Rejected |
+
+---
+
+### 5. Guest Order Access Policy
+
+**Status**: ⚠️ Policy Decision Required
+
+**Question**: How should guest orders (orders with no user_id) be accessed after checkout?
+
+**Current Behavior**:
+- Guest can view order on confirmation page immediately after checkout
+- No way to access order later (no account to log into)
+
+**Decision**: Maintain current behavior (Option A).
+**Rationale**:
+1. Spec states "Guest checkout functionality should continue to work" - this doesn't require adding new features
+2. Adding order lookup by email/order number is out of scope
+3. Simple implementation aligns with feature's security focus
+
+---
+
+### 6. Rails Authorization Best Practices
+
+**Research**: Rails controller authorization patterns
+
+**Best Practice for Simple Cases**:
+```ruby
+# Scope lookup to association - raises RecordNotFound if not found
+def set_order
+  @order = Current.user.orders.find(params[:id])
+end
+```
+
+**Handling Not Found**:
+- Rails default: Renders 404 page (acceptable)
+- Custom: Rescue and redirect with flash message (better UX)
+
+**Decision**: Use scoped lookup with custom RecordNotFound handling.
+**Rationale**: Provides both security (can't access others' orders) and good UX (helpful error message instead of 404).
+
+---
+
+### 7. Test Coverage Analysis
+
+**Current Test Files**:
+- `test/controllers/orders_controller_test.rb` - Exists but needs authorization tests
+- No dedicated integration or system tests for order authorization
+
+**Required Test Scenarios**:
+1. User can view own order (happy path)
+2. User cannot view another user's order (security)
+3. User cannot view guest order (security)
+4. Unauthenticated user redirected to login
+
+**Decision**: Add controller tests for authorization; add system test for user journey.
+**Rationale**: Constitution requires test-first development and coverage for security-critical flows.
+
+## Implementation Recommendations
+
+1. **Modify `set_order` method** to scope to current user's orders
+2. **Add `rescue_from ActiveRecord::RecordNotFound`** with redirect to orders index
+3. **Write failing tests first** per TDD requirements
+4. **Keep changes minimal** - only fix the authorization gap
+
+## Open Questions
+
+None - all clarifications resolved through codebase analysis.

--- a/specs/009-order-user-association/spec.md
+++ b/specs/009-order-user-association/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Order User Association
+
+**Feature Branch**: `009-order-user-association`
+**Created**: 2025-11-26
+**Status**: Complete
+**Input**: User description: "When an order is created, if the user is currently logged in, that order should be associated to this user, so that they can view their order and order history."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Order History (Priority: P1)
+
+A logged-in user navigates to their order history page to see all orders they have placed. They can see a list of their past orders with key information (order number, date, total, status) and click on any order to view its details.
+
+**Why this priority**: This is the core value proposition - users need to access their order history to track purchases, reference past orders, and manage their account effectively.
+
+**Independent Test**: Can be fully tested by having a logged-in user with existing orders navigate to the orders page and verify they see only their orders with correct details.
+
+**Acceptance Scenarios**:
+
+1. **Given** a logged-in user with 3 past orders, **When** they navigate to the order history page, **Then** they see all 3 orders listed with order number, date, status, and total for each
+2. **Given** a logged-in user with no past orders, **When** they navigate to the order history page, **Then** they see an empty state message indicating no orders exist
+3. **Given** a logged-in user, **When** they click on an order in their order history, **Then** they are taken to the order details page showing full order information
+
+---
+
+### User Story 2 - Order Associated at Checkout (Priority: P1)
+
+When a logged-in user completes checkout and payment, the resulting order is automatically associated with their account. They can immediately view the order in their order history after purchase.
+
+**Why this priority**: This is the foundational mechanism that enables all other order history functionality. Without this, users cannot build an order history.
+
+**Independent Test**: Can be fully tested by logging in, completing a purchase, and verifying the new order appears in the user's order history.
+
+**Acceptance Scenarios**:
+
+1. **Given** a logged-in user with items in their cart, **When** they complete checkout and payment, **Then** the created order is associated with their user account
+2. **Given** a logged-in user who just completed checkout, **When** they navigate to their order history, **Then** the new order appears in the list
+3. **Given** a guest user (not logged in) with items in their cart, **When** they complete checkout and payment, **Then** the order is created without a user association
+
+---
+
+### User Story 3 - Order Access Authorization (Priority: P1)
+
+Users can only view orders that belong to them. Attempting to access another user's order results in appropriate access denial.
+
+**Why this priority**: This is a security requirement - users must not be able to view other customers' order information (addresses, items purchased, payment details).
+
+**Independent Test**: Can be fully tested by attempting to access an order URL belonging to a different user and verifying access is denied.
+
+**Acceptance Scenarios**:
+
+1. **Given** a logged-in user, **When** they attempt to view an order that belongs to them, **Then** they can view the order details
+2. **Given** a logged-in user, **When** they attempt to view an order that belongs to a different user, **Then** they are denied access with an appropriate message
+3. **Given** a guest user (not logged in), **When** they attempt to access an order details page directly via URL, **Then** they are redirected to login
+
+---
+
+### Edge Cases
+
+- What happens when a user creates an account after placing guest orders? (Orders placed as guest remain unassociated - no retroactive linking)
+- What happens if a user logs in during checkout after starting as a guest? (Order should be associated with the logged-in user at time of payment completion)
+- How are orders displayed when a user is part of an organization? (Organization orders are handled separately and out of scope for this feature)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST associate orders with the logged-in user when checkout is completed
+- **FR-002**: System MUST allow logged-in users to view a list of their past orders
+- **FR-003**: System MUST restrict order viewing to only orders belonging to the logged-in user
+- **FR-004**: System MUST display order history in reverse chronological order (most recent first)
+- **FR-005**: System MUST show order number, date, status, and total amount in order list
+- **FR-006**: System MUST allow users to click through from order list to order details
+- **FR-007**: System MUST display an empty state when a user has no orders
+- **FR-008**: System MUST redirect unauthenticated users to login when attempting to access order pages
+- **FR-009**: System MUST redirect users to an appropriate page with error message when attempting to access another user's order
+
+### Key Entities
+
+- **User**: Customer account with authentication credentials; owns zero or more orders
+- **Order**: Purchase transaction record; belongs to zero or one user (guest orders have no user)
+- **Order History**: List view of orders belonging to a specific user
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of orders placed by logged-in users are correctly associated with their account
+- **SC-002**: Users can view their complete order history within 2 seconds of page load
+- **SC-003**: 100% of unauthorized order access attempts are blocked
+- **SC-004**: Users can navigate from order history to order details in a single click
+- **SC-005**: Order history page clearly communicates when no orders exist
+
+## Assumptions
+
+- The database already has a user_id column on the orders table (confirmed: `belongs_to :user, optional: true`)
+- Users already have an account and authentication mechanism in place (confirmed: Rails 8 authentication)
+- Guest checkout functionality should continue to work (orders created without user association)
+- Order history is accessed through a dedicated page in the user's account area
+- No retroactive association of guest orders to newly created accounts (out of scope)
+- Organization orders are handled separately and are out of scope for this feature

--- a/specs/009-order-user-association/tasks.md
+++ b/specs/009-order-user-association/tasks.md
@@ -1,0 +1,208 @@
+# Tasks: Order User Association
+
+**Input**: Design documents from `/specs/009-order-user-association/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, quickstart.md
+
+**Tests**: Required per Constitution (Test-First Development is NON-NEGOTIABLE)
+
+**Organization**: Tasks organized by user story. Note: US1 and US2 are already implemented - only US3 requires work.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Rails app**: `app/`, `test/` at repository root
+- **Controllers**: `app/controllers/`
+- **Tests**: `test/controllers/`, `test/integration/`, `test/system/`
+- **Fixtures**: `test/fixtures/`
+
+---
+
+## Phase 1: Setup (Verification)
+
+**Purpose**: Verify existing implementation and prepare test infrastructure
+
+- [x] T001 Verify existing order-user association works by reviewing `app/models/order.rb` and `app/models/user.rb`
+- [x] T002 Verify checkout associates orders with users by reviewing `app/controllers/checkouts_controller.rb:150-154`
+- [x] T003 Verify order index is scoped to current user in `app/controllers/orders_controller.rb:10`
+- [x] T004 Add guest order fixture without user_id in `test/fixtures/orders.yml`
+
+---
+
+## Phase 2: Foundational (Test Fixtures)
+
+**Purpose**: Ensure test fixtures support authorization testing scenarios
+
+**CRITICAL**: These fixtures must exist before authorization tests can run
+
+- [x] T005 Verify fixture `orders(:one)` belongs to `users(:one)` in `test/fixtures/orders.yml`
+- [x] T006 Verify fixture `orders(:two)` belongs to `users(:two)` in `test/fixtures/orders.yml`
+- [x] T007 Verify guest order fixture exists (order with `user: null`) in `test/fixtures/orders.yml`
+
+**Checkpoint**: Test fixtures ready - authorization tests can now be written
+
+---
+
+## Phase 3: User Story 1 - View Order History (Priority: P1) - ALREADY IMPLEMENTED
+
+**Goal**: Users can see list of their past orders with key information
+
+**Independent Test**: Navigate to /orders as logged-in user and verify order list displays
+
+**Status**: ✅ Already working - order index scoped to `Current.user.orders.recent`
+
+### Verification Tasks Only
+
+- [x] T008 [US1] Verify order history page renders for user with orders by running manual test
+- [x] T009 [US1] Verify empty state displays for user with no orders by running manual test
+
+**Checkpoint**: US1 confirmed working - no code changes needed
+
+---
+
+## Phase 4: User Story 2 - Order Associated at Checkout (Priority: P1) - ALREADY IMPLEMENTED
+
+**Goal**: Orders are automatically linked to logged-in users at checkout
+
+**Independent Test**: Complete checkout while logged in, verify order appears in order history
+
+**Status**: ✅ Already working - checkout passes `client_reference_id` to Stripe and creates order with user
+
+### Verification Tasks Only
+
+- [x] T010 [US2] Verify checkout code associates user via `stripe_session.client_reference_id` in `app/controllers/checkouts_controller.rb`
+- [x] T011 [US2] Verify guest checkout still works (no user association) by reviewing checkout flow
+
+**Checkpoint**: US2 confirmed working - no code changes needed
+
+---
+
+## Phase 5: User Story 3 - Order Access Authorization (Priority: P1) 🎯 NEEDS IMPLEMENTATION
+
+**Goal**: Users can only view orders that belong to them; unauthorized access is denied
+
+**Independent Test**: Attempt to access another user's order URL and verify redirect with error message
+
+**Status**: ❌ SECURITY VULNERABILITY - `set_order` fetches any order by ID without authorization
+
+### Tests for User Story 3 (REQUIRED - TDD)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T012 [P] [US3] Write controller test for user viewing own order (allowed) in `test/controllers/orders_controller_test.rb`
+- [x] T013 [P] [US3] Write controller test for user viewing another user's order (denied) in `test/controllers/orders_controller_test.rb`
+- [x] T014 [P] [US3] Write controller test for user viewing guest order (denied) in `test/controllers/orders_controller_test.rb`
+- [x] T015 [US3] Run tests to verify they FAIL (red phase): `rails test test/controllers/orders_controller_test.rb`
+
+### Implementation for User Story 3
+
+- [x] T016 [US3] Update `set_order` method to scope to current user's orders in `app/controllers/orders_controller.rb`
+- [x] T017 [US3] Add `rescue ActiveRecord::RecordNotFound` with redirect to orders_path in `app/controllers/orders_controller.rb`
+
+### Verification for User Story 3
+
+- [x] T018 [US3] Run tests to verify they PASS (green phase): `rails test test/controllers/orders_controller_test.rb`
+- [x] T019 [US3] Run full test suite to ensure no regressions: `rails test`
+- [x] T020 [US3] Run RuboCop linter: `rubocop app/controllers/orders_controller.rb`
+- [x] T021 [US3] Run Brakeman security scan: `brakeman`
+
+**Checkpoint**: User Story 3 complete - authorization enforced, tests passing
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and documentation
+
+- [x] T022 Manual verification: Log in as `users(:one)`, access `orders(:one)` - should succeed
+- [x] T023 Manual verification: Log in as `users(:one)`, access `orders(:two)` - should redirect with error
+- [x] T024 Manual verification: Log in as `users(:one)`, access guest order - should redirect with error
+- [x] T025 Update spec.md status from Draft to Complete
+- [x] T026 Run quickstart.md verification checklist
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verification only
+- **Foundational (Phase 2)**: Depends on Setup - fixture verification
+- **US1 (Phase 3)**: Depends on Foundational - verification only (already implemented)
+- **US2 (Phase 4)**: Depends on Foundational - verification only (already implemented)
+- **US3 (Phase 5)**: Depends on Foundational - **REQUIRES IMPLEMENTATION**
+- **Polish (Phase 6)**: Depends on US3 completion
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Already implemented - verification only
+- **User Story 2 (P1)**: Already implemented - verification only
+- **User Story 3 (P1)**: Depends on fixtures being ready - **PRIMARY WORK**
+
+### Within User Story 3 (TDD Workflow)
+
+1. Write all tests (T012-T014) - can run in parallel [P]
+2. Verify tests fail (T015) - MUST happen before implementation
+3. Implement fix (T016-T017) - sequential
+4. Verify tests pass (T018-T021) - sequential
+
+### Parallel Opportunities
+
+- Tests T012, T013, T014 can all be written in parallel (different test cases, same file)
+- Setup verification tasks T001-T004 can run in parallel
+- Manual verification tasks T022-T024 can run in parallel
+
+---
+
+## Parallel Example: User Story 3 Tests
+
+```bash
+# Launch all authorization tests together (they test different scenarios):
+Task: "Write controller test for user viewing own order (allowed)"
+Task: "Write controller test for user viewing another user's order (denied)"
+Task: "Write controller test for user viewing guest order (denied)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 3 Only)
+
+Since US1 and US2 are already implemented, the MVP is:
+
+1. Complete Phase 1-2: Verify existing implementation and fixtures
+2. Complete Phase 5: User Story 3 (authorization fix)
+3. **STOP and VALIDATE**: All authorization tests passing
+4. Complete Phase 6: Manual verification
+
+### TDD Strict Workflow
+
+1. Write failing tests (T012-T014)
+2. Confirm tests fail (T015) - **DO NOT SKIP**
+3. Implement minimal fix (T016-T017)
+4. Confirm tests pass (T018)
+5. Run full suite + linters (T019-T021)
+
+### Time Estimate
+
+- Verification (Phases 1-4): ~15 minutes
+- Tests (T012-T015): ~30 minutes
+- Implementation (T016-T017): ~15 minutes
+- Verification (T018-T021): ~10 minutes
+- Polish (Phase 6): ~15 minutes
+- **Total: ~1.5 hours**
+
+---
+
+## Notes
+
+- [P] tasks = can run in parallel (different test cases)
+- [US3] is the only story requiring implementation
+- Constitution requires tests written FIRST and FAILING before implementation
+- Commit after each logical group (tests, implementation, verification)
+- The security fix is minimal - single method change in controller

--- a/test/controllers/orders_controller_test.rb
+++ b/test/controllers/orders_controller_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class OrdersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user_one = users(:one)
+    @user_two = users(:two)
+    @order_one = orders(:one)      # belongs to user_one
+    @order_two = orders(:two)      # belongs to user_two
+    @guest_order = orders(:guest_order)  # no user association
+    @valid_password = "password"
+  end
+
+  # Helper to sign in a user
+  def sign_in(user)
+    post session_url, params: {
+      email_address: user.email_address,
+      password: @valid_password
+    }
+  end
+
+  # GET /orders (index)
+  test "index requires authentication" do
+    get orders_url
+    assert_redirected_to new_session_path
+  end
+
+  test "index shows only current user's orders" do
+    sign_in @user_one
+    get orders_url
+    assert_response :success
+    assert_select "h1", "Your Orders"
+  end
+
+  # GET /orders/:id (show) - Authorization tests
+
+  # T012: User viewing own order (allowed)
+  test "show displays own order" do
+    sign_in @user_one
+    get order_url(@order_one)
+    assert_response :success
+    assert_select "h1", "Order Confirmed!"
+  end
+
+  # T013: User viewing another user's order (denied)
+  test "show redirects when accessing another user's order" do
+    sign_in @user_one
+    get order_url(@order_two)  # order_two belongs to user_two
+    assert_redirected_to orders_path
+    assert_equal "Order not found", flash[:alert]
+  end
+
+  # T014: User viewing guest order (denied)
+  test "show redirects when accessing guest order" do
+    sign_in @user_one
+    get order_url(@guest_order)  # guest_order has no user
+    assert_redirected_to orders_path
+    assert_equal "Order not found", flash[:alert]
+  end
+
+  test "show requires authentication" do
+    get order_url(@order_one)
+    assert_redirected_to new_session_path
+  end
+
+  # Additional authorization tests - verify bidirectional protection
+  test "user two cannot view user one's order" do
+    sign_in @user_two
+    get order_url(@order_one)
+    assert_redirected_to orders_path
+    assert_equal "Order not found", flash[:alert]
+  end
+end

--- a/test/fixtures/order_items.yml
+++ b/test/fixtures/order_items.yml
@@ -43,8 +43,8 @@ acme_branded_item:
     size: "12oz"
     quantity: 5000
 
-complete_order_item_one:
-  order: complete_order
+guest_order_item_one:
+  order: guest_order
   product: one
   product_variant: one
   product_name: Eco Coffee Cup
@@ -53,8 +53,8 @@ complete_order_item_one:
   quantity: 2
   line_total: 20.00
 
-complete_order_item_two:
-  order: complete_order
+guest_order_item_two:
+  order: guest_order
   product: two
   product_variant: two
   product_name: Bamboo Cutlery Set

--- a/test/fixtures/orders.yml
+++ b/test/fixtures/orders.yml
@@ -53,16 +53,18 @@ acme_order:
   shipping_country: GB
   created_at: <%= 2.days.ago %>
 
-complete_order:
-  email: customer@example.com
-  stripe_session_id: cs_test_complete
-  order_number: ORD-2025-001234
+# Guest order (no user association) - for authorization testing
+guest_order:
+  # user: intentionally omitted - this is a guest checkout order
+  email: guest@example.com
+  stripe_session_id: cs_test_guest
+  order_number: ORD-2025-GUEST1
   status: paid
   subtotal_amount: 35.00
   vat_amount: 7.00
   shipping_amount: 5.00
   total_amount: 47.00
-  shipping_name: John Doe
+  shipping_name: Guest Customer
   shipping_address_line1: 123 Main Street
   shipping_city: London
   shipping_postal_code: SW1A 1AA


### PR DESCRIPTION
## Summary

- Fix security vulnerability in `OrdersController#show` that allowed any authenticated user to view any order by guessing/incrementing IDs
- Scope order lookup to `Current.user.orders` to ensure users can only view their own orders
- Add `rescue ActiveRecord::RecordNotFound` with redirect and flash message for graceful error handling
- Add comprehensive controller tests for authorization scenarios
- Update fixtures to include guest order for testing edge cases

## Security Fix

This addresses **FR-003**: System MUST restrict order viewing to only orders belonging to the logged-in user.

### Before (vulnerable)
```ruby
def set_order
  @order = Order.includes(order_items: :product_variant).find(params[:id])
end
```

### After (secure)
```ruby
def set_order
  @order = Current.user.orders.includes(order_items: :product_variant).find(params[:id])
rescue ActiveRecord::RecordNotFound
  redirect_to orders_path, alert: "Order not found"
end
```

## Test Plan

- [x] User can view their own order (allowed)
- [x] User cannot view another user's order (redirected with error)
- [x] User cannot view guest orders (redirected with error)
- [x] Unauthenticated user redirected to login
- [x] RuboCop passes
- [x] Brakeman security scan passes

## Files Changed

- `app/controllers/orders_controller.rb` - Add authorization to `set_order` method
- `test/controllers/orders_controller_test.rb` - New authorization tests
- `test/fixtures/orders.yml` - Add guest order fixture
- `test/fixtures/order_items.yml` - Update fixture references
- `specs/009-order-user-association/` - Feature specification and implementation docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)