### PR TITLE
Remove finish (matte/gloss) option from branded product configurator

### DIFF
--- a/app/frontend/javascript/controllers/branded_configurator_controller.js
+++ b/app/frontend/javascript/controllers/branded_configurator_controller.js
@@ -3,7 +3,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [
     "sizeOption",
-    "finishOption",
     "quantityOption",
     "pricePerUnit",
     "savingsBadge",
@@ -16,12 +15,10 @@ export default class extends Controller {
     "designPreview",
     "errorMessage",
     "sizeIndicator",
-    "finishIndicator",
     "quantityIndicator",
     "lidsIndicator",
     "designIndicator",
     "sizeStep",
-    "finishStep",
     "quantityStep",
     "lidsStep",
     "designStep",
@@ -36,7 +33,6 @@ export default class extends Controller {
 
   connect() {
     this.selectedSize = null
-    this.selectedFinish = null
     this.selectedQuantity = null
     this.calculatedPrice = null
     this.updateAddToCartButton()
@@ -62,18 +58,6 @@ export default class extends Controller {
       )
       if (sizeButton) {
         sizeButton.click()
-      }
-    }
-
-    // Pre-select finish if in URL (normalize: "matte" → "Matte", "gloss" → "Gloss")
-    const finishParam = params.get('finish')
-    if (finishParam) {
-      const normalizedFinish = finishParam.charAt(0).toUpperCase() + finishParam.slice(1).toLowerCase()
-      const finishButton = this.finishOptionTargets.find(el =>
-        el.dataset.finish.toLowerCase() === finishParam.toLowerCase()
-      )
-      if (finishButton) {
-        finishButton.click()
       }
     }
 
@@ -105,23 +89,6 @@ export default class extends Controller {
     this.updateUrl()
     this.showStepComplete('size')
     this.calculatePrice()
-  }
-
-  selectFinish(event) {
-    // Reset all finish buttons to unselected state
-    this.finishOptionTargets.forEach(el => {
-      el.classList.remove("border-primary", "border-4")
-      el.classList.add("border-gray-300", "border-2")
-    })
-
-    // Add selected state to clicked button
-    event.currentTarget.classList.remove("border-gray-300", "border-2")
-    event.currentTarget.classList.add("border-primary", "border-4")
-
-    this.selectedFinish = event.currentTarget.dataset.finish
-    this.updateUrl()
-    this.showStepComplete('finish')
-    this.updateAddToCartButton()
   }
 
   selectQuantity(event) {
@@ -407,9 +374,6 @@ export default class extends Controller {
     if (this.selectedSize) {
       params.set('size', this.selectedSize)
     }
-    if (this.selectedFinish) {
-      params.set('finish', this.selectedFinish)
-    }
     if (this.selectedQuantity) {
       params.set('quantity', this.selectedQuantity)
     }
@@ -431,8 +395,8 @@ export default class extends Controller {
     // Open next step in accordion
     // In modal mode, skip lids step and go directly from quantity to design
     const stepMap = this.inModalValue
-      ? { size: 'finish', finish: 'quantity', quantity: 'design', design: null }
-      : { size: 'finish', finish: 'quantity', quantity: 'lids', lids: 'design' }
+      ? { size: 'quantity', quantity: 'design', design: null }
+      : { size: 'quantity', quantity: 'lids', lids: 'design' }
 
     const nextStep = stepMap[step]
     if (nextStep) {
@@ -511,7 +475,6 @@ export default class extends Controller {
     if (!this.hasAddToCartButtonTarget) return
 
     const isValid = this.selectedSize &&
-                    this.selectedFinish &&
                     this.selectedQuantity &&
                     this.calculatedPrice &&
                     this.designInputTarget?.files.length > 0
@@ -546,11 +509,6 @@ export default class extends Controller {
       return
     }
 
-    if (!this.selectedFinish) {
-      this.showError("Please select a finish")
-      return
-    }
-
     if (!this.selectedQuantity) {
       this.showError("Please select a quantity")
       return
@@ -569,7 +527,6 @@ export default class extends Controller {
     const formData = new FormData()
     formData.append("product_id", this.productIdValue)
     formData.append("configuration[size]", this.selectedSize)
-    formData.append("configuration[finish]", this.selectedFinish)
     formData.append("configuration[quantity]", this.selectedQuantity)
     formData.append("calculated_price", this.calculatedPrice)
 
@@ -614,18 +571,11 @@ export default class extends Controller {
   resetConfigurator() {
     // Reset state variables
     this.selectedSize = null
-    this.selectedFinish = null
     this.selectedQuantity = null
     this.calculatedPrice = null
 
     // Reset size buttons
     this.sizeOptionTargets.forEach(el => {
-      el.classList.remove("border-primary", "border-4")
-      el.classList.add("border-gray-300", "border-2")
-    })
-
-    // Reset finish buttons
-    this.finishOptionTargets.forEach(el => {
       el.classList.remove("border-primary", "border-4")
       el.classList.add("border-gray-300", "border-2")
     })
@@ -647,7 +597,7 @@ export default class extends Controller {
     }
 
     // Reset step indicators
-    const indicators = ['size', 'finish', 'quantity', 'lids', 'design']
+    const indicators = ['size', 'quantity', 'lids', 'design']
     indicators.forEach(step => {
       const indicatorTarget = `${step}IndicatorTarget`
       if (this[indicatorTarget]) {

--- a/app/views/branded_products/_branded_configurator.html.erb
+++ b/app/views/branded_products/_branded_configurator.html.erb
@@ -91,38 +91,11 @@
           </div>
         </div>
 
-        <!-- Step 2: Select Finish -->
-        <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="finishStep">
-          <input type="radio" name="config-accordion" aria-label="Step 2: Select Finish" />
-          <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="finishIndicator">2</span>
-            Select Finish
-          </div>
-          <div class="collapse-content">
-            <div class="flex gap-2 pt-4">
-          <button type="button"
-                  class="bg-white border-2 border-gray-300 text-black hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                  data-branded-configurator-target="finishOption"
-                  data-finish="Matte"
-                  data-action="click->branded-configurator#selectFinish">
-            Matte
-          </button>
-          <button type="button"
-                  class="bg-white border-2 border-gray-300 text-black hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                  data-branded-configurator-target="finishOption"
-                  data-finish="Gloss"
-                  data-action="click->branded-configurator#selectFinish">
-            Gloss
-          </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Step 3: Select Quantity -->
+        <!-- Step 2: Select Quantity -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="quantityStep">
-          <input type="radio" name="config-accordion" aria-label="Step 3: Select Quantity" />
+          <input type="radio" name="config-accordion" aria-label="Step 2: Select Quantity" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">3</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">2</span>
             Select Quantity
           </div>
           <div class="collapse-content">
@@ -155,11 +128,11 @@
           </div>
         </div>
 
-        <!-- Step 4: Add Matching Lids (Optional) -->
+        <!-- Step 3: Add Matching Lids (Optional) -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="lidsStep">
-          <input type="radio" name="config-accordion" aria-label="Step 4: Add Matching Lids (Optional)" />
+          <input type="radio" name="config-accordion" aria-label="Step 3: Add Matching Lids (Optional)" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="lidsIndicator">4</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="lidsIndicator">3</span>
             Add Matching Lids (Optional)
           </div>
           <div class="collapse-content">
@@ -183,11 +156,11 @@
           </div>
         </div>
 
-        <!-- Step 5: Upload Design -->
+        <!-- Step 4: Upload Design -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="designStep">
-          <input type="radio" name="config-accordion" aria-label="Step 5: Upload Your Design" />
+          <input type="radio" name="config-accordion" aria-label="Step 4: Upload Your Design" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">5</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">4</span>
             Upload Your Design
           </div>
           <div class="collapse-content">

--- a/app/views/products/_branded_configurator.html.erb
+++ b/app/views/products/_branded_configurator.html.erb
@@ -91,38 +91,11 @@
           </div>
         </div>
 
-        <!-- Step 2: Select Finish -->
-        <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="finishStep">
-          <input type="radio" name="config-accordion" aria-label="Step 2: Select Finish" />
-          <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="finishIndicator">2</span>
-            Select Finish
-          </div>
-          <div class="collapse-content">
-            <div class="flex gap-2 pt-4">
-          <button type="button"
-                  class="bg-white border-2 border-gray-300 text-black hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                  data-branded-configurator-target="finishOption"
-                  data-finish="Matte"
-                  data-action="click->branded-configurator#selectFinish">
-            Matte
-          </button>
-          <button type="button"
-                  class="bg-white border-2 border-gray-300 text-black hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                  data-branded-configurator-target="finishOption"
-                  data-finish="Gloss"
-                  data-action="click->branded-configurator#selectFinish">
-            Gloss
-          </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Step 3: Select Quantity -->
+        <!-- Step 2: Select Quantity -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="quantityStep">
-          <input type="radio" name="config-accordion" aria-label="Step 3: Select Quantity" />
+          <input type="radio" name="config-accordion" aria-label="Step 2: Select Quantity" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">3</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">2</span>
             Select Quantity
           </div>
           <div class="collapse-content">
@@ -155,11 +128,11 @@
           </div>
         </div>
 
-        <!-- Step 4: Add Matching Lids (Optional) -->
+        <!-- Step 3: Add Matching Lids (Optional) -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="lidsStep">
-          <input type="radio" name="config-accordion" aria-label="Step 4: Add Matching Lids (Optional)" />
+          <input type="radio" name="config-accordion" aria-label="Step 3: Add Matching Lids (Optional)" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="lidsIndicator">4</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="lidsIndicator">3</span>
             Add Matching Lids (Optional)
           </div>
           <div class="collapse-content">
@@ -183,11 +156,11 @@
           </div>
         </div>
 
-        <!-- Step 5: Upload Design -->
+        <!-- Step 4: Upload Design -->
         <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="designStep">
-          <input type="radio" name="config-accordion" aria-label="Step 5: Upload Your Design" />
+          <input type="radio" name="config-accordion" aria-label="Step 4: Upload Your Design" />
           <div class="collapse-title text-lg flex items-center gap-2">
-            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">5</span>
+            <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">4</span>
             Upload Your Design
           </div>
           <div class="collapse-content">

--- a/app/views/products/_branded_configurator_modal.html.erb
+++ b/app/views/products/_branded_configurator_modal.html.erb
@@ -50,38 +50,11 @@
             </div>
           </div>
 
-          <!-- Step 2: Select Finish -->
-          <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="finishStep">
-            <input type="radio" name="modal-config-accordion" />
-            <div class="collapse-title text-lg font-semibold flex items-center gap-2">
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="finishIndicator">2</span>
-              Select Finish
-            </div>
-            <div class="collapse-content">
-              <div class="flex gap-2 pt-4">
-                <button type="button"
-                        class="bg-white border-2 border-gray-300 text-black font-semibold hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                        data-branded-configurator-target="finishOption"
-                        data-finish="Matte"
-                        data-action="click->branded-configurator#selectFinish">
-                  Matte
-                </button>
-                <button type="button"
-                        class="bg-white border-2 border-gray-300 text-black font-semibold hover:border-primary rounded-full px-6 py-3 transition cursor-pointer"
-                        data-branded-configurator-target="finishOption"
-                        data-finish="Gloss"
-                        data-action="click->branded-configurator#selectFinish">
-                  Gloss
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <!-- Step 3: Select Quantity -->
+          <!-- Step 2: Select Quantity -->
           <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="quantityStep">
             <input type="radio" name="modal-config-accordion" />
             <div class="collapse-title text-lg font-semibold flex items-center gap-2">
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">3</span>
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="quantityIndicator">2</span>
               Select Quantity
             </div>
             <div class="collapse-content">
@@ -114,11 +87,11 @@
             </div>
           </div>
 
-          <!-- Step 4: Upload Design (no lids step in modal) -->
+          <!-- Step 3: Upload Design (no lids step in modal) -->
           <div class="collapse collapse-arrow bg-base-200" data-branded-configurator-target="designStep">
             <input type="radio" name="modal-config-accordion" />
             <div class="collapse-title text-lg font-semibold flex items-center gap-2">
-              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">4</span>
+              <span class="flex items-center justify-center w-6 h-6 rounded-full bg-gray-300 text-white text-sm font-bold" data-branded-configurator-target="designIndicator">3</span>
               Upload Your Design
             </div>
             <div class="collapse-content">

--- a/test/system/branded_product_ordering_test.rb
+++ b/test/system/branded_product_ordering_test.rb
@@ -20,22 +20,18 @@ class BrandedProductOrderingTest < ApplicationSystemTestCase
     click_button "12oz"
     assert_selector ".border-primary", text: "12oz"
 
-    # Step 2: Select finish - open accordion by clicking hidden radio
-    find("[data-branded-configurator-target='finishStep'] input[type='radio']", visible: false).click
-    click_button "Matte"
-
-    # Step 3: Select quantity - open accordion by clicking hidden radio
+    # Step 2: Select quantity - open accordion by clicking hidden radio
     find("[data-branded-configurator-target='quantityStep'] input[type='radio']", visible: false).click
     find("[data-quantity='5000']").click
 
     # Wait for price calculation (wait for non-zero price)
     assert_selector "[data-branded-configurator-target='total']", text: /£[1-9]/
 
-    # Step 4: Skip lids (optional step) - open accordion by clicking hidden radio
+    # Step 3: Skip lids (optional step) - open accordion by clicking hidden radio
     find("[data-branded-configurator-target='lidsStep'] input[type='radio']", visible: false).click
     click_button "Skip - No lids needed"
 
-    # Step 5: Upload design - open accordion by clicking hidden radio
+    # Step 4: Upload design - open accordion by clicking hidden radio
     find("[data-branded-configurator-target='designStep'] input[type='radio']", visible: false).click
     find("[data-branded-configurator-target='designInput']").attach_file(Rails.root.join("test", "fixtures", "files", "test_design.pdf"))
     assert_text "test_design.pdf"
@@ -44,7 +40,7 @@ class BrandedProductOrderingTest < ApplicationSystemTestCase
     assert_no_selector ".btn-disabled", text: "Add to Cart"
     assert_selector ".btn-primary", text: "Add to Cart"
 
-    # Step 6: Add to cart
+    # Step 5: Add to cart
     click_button "Add to Cart"
 
     # Navigate to cart to verify item was added
@@ -63,13 +59,6 @@ class BrandedProductOrderingTest < ApplicationSystemTestCase
 
     # Select size only
     click_button "12oz"
-
-    # Still disabled (missing finish, quantity and design)
-    assert_selector ".btn-disabled", text: "Add to Cart"
-
-    # Select finish - open accordion by clicking hidden radio
-    find("[data-branded-configurator-target='finishStep'] input[type='radio']", visible: false).click
-    click_button "Matte"
 
     # Still disabled (missing quantity and design)
     assert_selector ".btn-disabled", text: "Add to Cart"


### PR DESCRIPTION
## Summary
- Remove Step 2 (Select Finish) from all configurator views
- Simplify branded product flow: Size → Quantity → Lids → Design
- Remove finish-related code from Stimulus controller

## Test plan
- [ ] Verify branded product configurator works without finish step
- [ ] Confirm step numbering is correct (1-4)
- [ ] System tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)