### PR TITLE
Remove VAT calculations from price displays

### DIFF
--- a/app/frontend/javascript/controllers/branded_configurator_controller.js
+++ b/app/frontend/javascript/controllers/branded_configurator_controller.js
@@ -32,7 +32,6 @@ export default class extends Controller {
 
   static values = {
     productId: Number,
-    vatRate: { type: Number, default: 0.2 },
     inModal: { type: Boolean, default: false }
   }
 


### PR DESCRIPTION
## Summary
This PR removes VAT (Value Added Tax) calculations from all price displays throughout the branded configurator, ensuring all prices are shown excluding VAT only.

## Key Changes
- **Price per unit display**: Removed VAT multiplication when displaying unit prices
- **Total price display**: Changed to show subtotal directly instead of adding VAT
- **Summary display**: 
  - Removed VAT line item calculation and display
  - Updated total to show subtotal (excl. VAT) instead of subtotal + VAT
  - Added clarifying comment that all prices are displayed excl. VAT

## Implementation Details
- All price formatting remains consistent with 2-3 decimal places as appropriate
- The `vatRateValue` property is no longer used in price display calculations
- Server continues to return `total_price` as the base price (excl. VAT)
- This change simplifies the UI by removing VAT from the customer-facing display while maintaining the underlying data structure

https://claude.ai/code/session_01TqmdJvTpMuACT7E7UThPw3