### PR TITLE
Add programmatic SEO system for business type pages (/for/:business-type)

### DIFF
--- a/app/controllers/pseo_controller.rb
+++ b/app/controllers/pseo_controller.rb
@@ -1,0 +1,22 @@
+class PseoController < ApplicationController
+  allow_unauthenticated_access
+
+  def business_type
+    slug = params[:business_type]
+
+    raise ActionController::RoutingError, "Not Found" unless valid_slug?(slug)
+
+    json_path = Rails.root.join("lib/data/pseo/pages/for/#{slug}.json")
+
+    raise ActionController::RoutingError, "Not Found" unless json_path.exist?
+
+    @page = JSON.parse(json_path.read, symbolize_names: true)
+    @client_logos = helpers.client_logos
+  end
+
+  private
+
+  def valid_slug?(slug)
+    slug.present? && slug.match?(/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,16 @@ module ApplicationHelper
     CLIENT_LOGOS
   end
 
+  # Find a client logo file by client name (case-insensitive fuzzy match)
+  # Used by PSEO pages to show relevant client logos
+  def find_client_logo(client_name)
+    normalized = client_name.downcase.gsub(/[^a-z0-9]/, "")
+    CLIENT_LOGOS.find do |logo|
+      logo_name = logo.split(".").first.tr("-", "").downcase
+      logo_name.include?(normalized) || normalized.include?(logo_name)
+    end
+  end
+
   def category_icon_path(category)
     icon_mapping = {
       "cups-and-lids" => "images/graphics/cold-cups.svg",

--- a/app/services/pseo_page_validator_service.rb
+++ b/app/services/pseo_page_validator_service.rb
@@ -1,0 +1,99 @@
+class PseoPageValidatorService
+  REQUIRED_SECTIONS = %i[meta hero packaging_needs sustainability_section faqs social_proof].freeze
+  REQUIRED_META_FIELDS = %i[slug business_type seo_title seo_description keywords].freeze
+  REQUIRED_HERO_FIELDS = %i[headline subheadline intro].freeze
+  PACKAGING_NEEDS_RANGE = (4..6).freeze
+  REQUIRED_FAQ_COUNT = 5
+  INTRO_WORD_RANGE = (150..200).freeze
+  FAQ_ANSWER_WORD_RANGE = (60..100).freeze
+
+  def initialize(data)
+    @data = data
+    @errors = []
+  end
+
+  def validate
+    validate_required_sections
+    validate_meta if @data[:meta]
+    validate_hero if @data[:hero]
+    validate_packaging_needs if @data[:packaging_needs]
+    validate_faqs if @data[:faqs]
+    validate_sustainability_section if @data[:sustainability_section]
+    validate_social_proof if @data[:social_proof]
+
+    { valid: @errors.empty?, errors: @errors }
+  end
+
+  private
+
+  def validate_required_sections
+    REQUIRED_SECTIONS.each do |section|
+      @errors << "Missing required section: #{section}" unless @data[section].present?
+    end
+  end
+
+  def validate_meta
+    meta = @data[:meta]
+    REQUIRED_META_FIELDS.each do |field|
+      @errors << "Missing or empty meta field: #{field}" if meta[field].blank?
+    end
+  end
+
+  def validate_hero
+    hero = @data[:hero]
+    REQUIRED_HERO_FIELDS.each do |field|
+      @errors << "Missing or empty hero field: #{field}" if hero[field].blank?
+    end
+
+    if hero[:intro].present?
+      word_count = hero[:intro].split.size
+      unless INTRO_WORD_RANGE.include?(word_count)
+        @errors << "Hero intro word count is #{word_count}, must be #{INTRO_WORD_RANGE}"
+      end
+    end
+  end
+
+  def validate_packaging_needs
+    count = @data[:packaging_needs].size
+    unless PACKAGING_NEEDS_RANGE.include?(count)
+      @errors << "packaging_needs count is #{count}, must be #{PACKAGING_NEEDS_RANGE}"
+    end
+
+    @data[:packaging_needs].each_with_index do |need, i|
+      %i[category why_it_matters recommended_products buying_tip].each do |field|
+        @errors << "packaging_needs[#{i}] missing #{field}" if need[field].blank?
+      end
+    end
+  end
+
+  def validate_faqs
+    count = @data[:faqs].size
+    if count != REQUIRED_FAQ_COUNT
+      @errors << "faqs count is #{count}, must be exactly #{REQUIRED_FAQ_COUNT}"
+    end
+
+    @data[:faqs].each_with_index do |faq, i|
+      @errors << "faqs[#{i}] missing question" if faq[:question].blank?
+      @errors << "faqs[#{i}] missing answer" if faq[:answer].blank?
+
+      if faq[:answer].present?
+        word_count = faq[:answer].split.size
+        unless FAQ_ANSWER_WORD_RANGE.include?(word_count)
+          @errors << "faqs[#{i}] answer word count is #{word_count}, must be #{FAQ_ANSWER_WORD_RANGE}"
+        end
+      end
+    end
+  end
+
+  def validate_sustainability_section
+    sus = @data[:sustainability_section]
+    @errors << "sustainability_section missing intro" if sus[:intro].blank?
+    @errors << "sustainability_section missing options" if sus[:options].blank?
+  end
+
+  def validate_social_proof
+    sp = @data[:social_proof]
+    @errors << "social_proof missing relevant_clients" if sp[:relevant_clients].blank?
+    @errors << "social_proof missing testimonial_angle" if sp[:testimonial_angle].blank?
+  end
+end

--- a/app/services/sitemap_generator_service.rb
+++ b/app/services/sitemap_generator_service.rb
@@ -56,6 +56,17 @@ class SitemapGeneratorService
                   lastmod: product.updated_at)
         end
 
+        # PSEO business type pages
+        pseo_pages_dir = Rails.root.join("lib/data/pseo/pages/for")
+        if pseo_pages_dir.exist?
+          Dir.glob(pseo_pages_dir.join("*.json")).each do |file|
+            slug = File.basename(file, ".json")
+            add_url(xml, pseo_business_type_url(business_type: slug),
+                    priority: "0.8",
+                    changefreq: "monthly")
+          end
+        end
+
         # Blog posts (published only)
         add_url(xml, blog_posts_url, priority: "0.7", changefreq: "weekly")
         BlogPost.published.find_each do |post|

--- a/app/views/pseo/business_type.html.erb
+++ b/app/views/pseo/business_type.html.erb
@@ -1,0 +1,221 @@
+<% content_for :title, @page[:meta][:seo_title] %>
+<% content_for :meta_description, @page[:meta][:seo_description] %>
+
+<% content_for :og_tags_custom, true %>
+<% content_for :twitter_tags_custom, true %>
+<% content_for :head do %>
+  <%= canonical_url(pseo_business_type_url(business_type: @page[:meta][:slug])) %>
+
+  <meta name="keywords" content="<%= @page[:meta][:keywords].join(', ') %>">
+
+  <%# Open Graph %>
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="<%= @page[:meta][:seo_title] %>">
+  <meta property="og:description" content="<%= @page[:meta][:seo_description] %>">
+  <meta property="og:url" content="<%= pseo_business_type_url(business_type: @page[:meta][:slug]) %>">
+  <meta property="og:site_name" content="Afida">
+
+  <%# Twitter Card %>
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="<%= @page[:meta][:seo_title] %>">
+  <meta name="twitter:description" content="<%= @page[:meta][:seo_description] %>">
+
+  <%# Structured Data: BreadcrumbList %>
+  <script type="application/ld+json">
+    <%= breadcrumb_structured_data([
+      { name: "Home", url: root_url },
+      { name: @page[:meta][:business_type], url: pseo_business_type_url(business_type: @page[:meta][:slug]) }
+    ]).html_safe %>
+  </script>
+
+  <%# Structured Data: FAQPage %>
+  <script type="application/ld+json">
+    <%= raw({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": @page[:faqs].map { |faq|
+        {
+          "@type": "Question",
+          "name": faq[:question],
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": faq[:answer]
+          }
+        }
+      }
+    }.to_json) %>
+  </script>
+<% end %>
+
+<%# ==================== HERO SECTION ==================== %>
+<section class="w-screen relative left-[50%] right-[50%] -mx-[50vw] bg-neutral-900 overflow-hidden">
+  <%# Subtle dot pattern background %>
+  <div class="absolute inset-0 opacity-[0.04]" aria-hidden="true"></div>
+
+  <%# Decorative glows %>
+  <div class="absolute -top-20 -right-20 w-96 h-96 bg-[#79ebc0] rounded-full blur-[140px] opacity-15" aria-hidden="true"></div>
+  <div class="absolute -bottom-20 -left-20 w-72 h-72 bg-[#79ebc0] rounded-full blur-[120px] opacity-10" aria-hidden="true"></div>
+
+  <div class="container mx-auto px-4 py-16 lg:py-24 relative z-10">
+    <div class="max-w-4xl mx-auto text-center">
+      <h1 class="!text-4xl sm:!text-5xl lg:!text-6xl text-white mb-6">
+        <%= @page[:hero][:headline] %>
+      </h1>
+
+      <p class="text-xl text-[#79ebc0] mb-8">
+        <%= @page[:hero][:subheadline] %>
+      </p>
+
+      <p class="text-lg text-gray-300 leading-relaxed max-w-3xl mx-auto mb-10">
+        <%= @page[:hero][:intro] %>
+      </p>
+
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <%= link_to shop_path, class: "btn btn-primary btn-lg" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+          </svg>
+          Shop <%= @page[:meta][:business_type] %> Packaging
+        <% end %>
+        <%= link_to samples_path, class: "btn btn-outline btn-lg border border-white/20 text-white hover:bg-white/10 hover:border-white/40" do %>
+          Get Free Samples
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%# ==================== PACKAGING NEEDS ==================== %>
+<section class="py-12 sm:py-16" data-controller="scroll-reveal" data-scroll-reveal-self-value="true">
+  <div class="container mx-auto px-4">
+    <div class="text-center mb-10">
+      <h2 class="text-3xl md:text-4xl mb-4">What <%= @page[:meta][:business_type] %> Need</h2>
+      <div class="w-24 h-1 bg-[#79ebc0] mx-auto rounded-full"></div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-testid="packaging-needs">
+      <% @page[:packaging_needs].each do |need| %>
+        <div class="bg-base-100 rounded-2xl border border-base-200 p-6 hover:shadow-lg transition-shadow" data-testid="packaging-card">
+          <h3 class="text-xl mb-3"><%= need[:category] %></h3>
+          <p class="text-base-content/70 mb-4"><%= need[:why_it_matters] %></p>
+
+          <div class="bg-base-200 rounded-xl p-4 mb-4">
+            <p class="text-sm text-base-content/60 mb-1">Buying tip</p>
+            <p class="text-sm text-base-content/80"><%= need[:buying_tip] %></p>
+          </div>
+
+          <% if need[:recommended_products].present? %>
+            <div class="flex flex-wrap gap-2">
+              <% need[:recommended_products].each do |product_slug| %>
+                <%= link_to product_slug.titleize.gsub("-", " "),
+                      shop_path(q: product_slug.gsub("-", " ")),
+                      class: "badge badge-outline badge-sm gap-1 hover:badge-primary transition-colors" %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>
+
+<%# ==================== SUSTAINABILITY SECTION ==================== %>
+<section class="w-screen relative left-[50%] right-[50%] -mx-[50vw] bg-neutral-900 overflow-hidden" data-testid="sustainability-section">
+  <div class="absolute -top-32 -left-32 w-80 h-80 bg-[#79ebc0] rounded-full blur-[140px] opacity-10" aria-hidden="true"></div>
+
+  <div class="container mx-auto px-4 py-12 sm:py-16 relative z-10" data-controller="scroll-reveal" data-scroll-reveal-self-value="true">
+    <div class="text-center mb-10">
+      <h2 class="text-3xl md:text-4xl text-white mb-4">Sustainability Options</h2>
+      <div class="w-24 h-1 bg-[#79ebc0] mx-auto rounded-full mb-6"></div>
+      <p class="text-lg text-gray-300 max-w-3xl mx-auto"><%= @page[:sustainability_section][:intro] %></p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+      <% @page[:sustainability_section][:options].each do |option| %>
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-6">
+          <div class="flex items-start gap-4">
+            <div class="w-10 h-10 rounded-full bg-[#79ebc0]/15 border border-[#79ebc0]/30 flex items-center justify-center flex-shrink-0">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-[#79ebc0]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <div>
+              <h3 class="text-lg text-white mb-2"><%= option[:name] %></h3>
+              <p class="text-sm text-gray-400"><%= option[:benefit] %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>
+
+<%# ==================== SOCIAL PROOF ==================== %>
+<section class="py-8" data-testid="social-proof">
+  <div class="container mx-auto px-4">
+    <div class="text-center">
+      <p class="text-base-content/60 mb-4"><%= @page[:social_proof][:testimonial_angle] %></p>
+      <div class="flex flex-wrap justify-center gap-6 items-center">
+        <% @page[:social_proof][:relevant_clients].each do |client_name| %>
+          <% logo_file = find_client_logo(client_name) %>
+          <% if logo_file %>
+            <%= vite_image_tag "images/logos/#{logo_file}",
+                  alt: "#{client_name} - Afida client",
+                  class: "h-10 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300" %>
+          <% else %>
+            <span class="text-base-content/40 text-sm"><%= client_name %></span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%# ==================== FAQ SECTION ==================== %>
+<section class="py-12 sm:py-16 bg-base-200" data-controller="scroll-reveal" data-scroll-reveal-self-value="true">
+  <div class="container mx-auto px-4">
+    <div class="max-w-3xl mx-auto">
+      <div class="text-center mb-10">
+        <h2 class="text-3xl md:text-4xl mb-4">Frequently Asked Questions</h2>
+        <div class="w-24 h-1 bg-[#79ebc0] mx-auto rounded-full"></div>
+      </div>
+
+      <div class="space-y-2">
+        <% @page[:faqs].each_with_index do |faq, i| %>
+          <div class="collapse collapse-arrow bg-base-100 rounded-xl">
+            <input type="radio" name="pseo-faq" <%= "checked" if i == 0 %> />
+            <div class="collapse-title text-lg"><%= faq[:question] %></div>
+            <div class="collapse-content">
+              <p class="text-base-content/70"><%= faq[:answer] %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>
+
+<%# ==================== CTA SECTION ==================== %>
+<section class="w-screen relative left-[50%] right-[50%] -mx-[50vw] -mb-16 bg-neutral-900 overflow-hidden" data-testid="cta-section">
+  <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-[#79ebc0] rounded-full blur-[200px] opacity-[0.08]" aria-hidden="true"></div>
+
+  <div class="container mx-auto px-4 py-16 lg:py-24 relative z-10" data-controller="scroll-reveal" data-scroll-reveal-self-value="true">
+    <div class="max-w-3xl mx-auto text-center">
+      <h2 class="text-white text-3xl md:text-4xl mb-4">Ready to Order?</h2>
+      <p class="text-xl text-gray-400 mb-8">
+        Get everything your <%= @page[:meta][:business_type].downcase %> needs — eco-friendly, competitively priced, delivered fast. Free delivery over £100.
+      </p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <%= link_to shop_path, class: "btn btn-primary btn-lg" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+          </svg>
+          Shop <%= @page[:meta][:business_type] %> Packaging
+        <% end %>
+        <%= link_to samples_path, class: "btn btn-outline btn-lg border border-white/20 text-white hover:bg-white/10 hover:border-white/40" do %>
+          Get Free Samples
+        <% end %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
     end
   end
   get "vegware", to: "pages#vegware"
+
+  # Programmatic SEO: Business type pages
+  get "for/:business_type", to: "pseo#business_type", as: :pseo_business_type
   get "about", to: "pages#about"
   get "contact", to: "pages#contact"
   get "terms-conditions", to: "pages#terms_conditions"

--- a/lib/data/pseo/niches/bakeries.json
+++ b/lib/data/pseo/niches/bakeries.json
@@ -1,0 +1,17 @@
+{
+  "slug": "bakeries",
+  "name": "Bakeries",
+  "audience": "Artisan bakery owners, high-street bakeries, bread and pastry shops",
+  "pain_points": [
+    "Bread bags and pastry boxes are used in high volumes daily",
+    "Window patching on bags lets customers see the product — essential for sales",
+    "Greaseproof paper is needed for pastries, croissants, and doughnuts",
+    "Allergen labelling on pre-packed baked goods is complex with many ingredients"
+  ],
+  "top_products": ["bags-and-wraps", "cold-food-and-salads", "napkins", "supplies-and-essentials"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed baked goods", "Food Information Regulations (ingredient listing)"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium (3,000–10,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/breakfast-cafes.json
+++ b/lib/data/pseo/niches/breakfast-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "breakfast-cafes",
+  "name": "Breakfast Cafés",
+  "audience": "Greasy spoon operators, breakfast café owners, full English and brunch businesses",
+  "pain_points": [
+    "Early morning trade means packaging must be ready before dawn",
+    "Hot food containers for fry-ups must handle grease and steam",
+    "Builder's tea in high volumes needs affordable, sturdy cups",
+    "Takeaway breakfast wraps and baps need foil or greaseproof wrapping"
+  ],
+  "top_products": ["hot-food", "cups-and-lids", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed breakfast items", "Food hygiene rating display requirements"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (2,000–6,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/bubble-tea-shops.json
+++ b/lib/data/pseo/niches/bubble-tea-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "bubble-tea-shops",
+  "name": "Bubble Tea Shops",
+  "audience": "Bubble tea bar owners, boba franchise operators, Asian drink specialists",
+  "pain_points": [
+    "Need specialised wide-bore straws for tapioca pearls",
+    "Sealing film and dome lids are essential but hard to source sustainably",
+    "Younger customer base is vocal about sustainability",
+    "High Instagram visibility means branding on cups is critical"
+  ],
+  "top_products": ["cups-and-lids", "straws", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Plastic straw ban (England 2023) — need compliant wide-bore alternatives", "HFSS display restrictions for high-sugar drinks"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/burger-restaurants.json
+++ b/lib/data/pseo/niches/burger-restaurants.json
@@ -1,0 +1,17 @@
+{
+  "slug": "burger-restaurants",
+  "name": "Burger Restaurants",
+  "audience": "Independent burger joints, smash burger businesses, gourmet burger restaurants",
+  "pain_points": [
+    "Burger wraps and clamshells must keep food warm without going soggy",
+    "Fries packaging needs grease-proof liners",
+    "High delivery volume through Deliveroo/Uber Eats demands reliable packaging",
+    "Branded packaging is a key differentiator in a crowded market"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Calorie labelling for businesses with 250+ employees", "Natasha's Law allergen labelling for pre-packed items"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–8,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/butchers.json
+++ b/lib/data/pseo/niches/butchers.json
@@ -1,0 +1,17 @@
+{
+  "slug": "butchers",
+  "name": "Butchers",
+  "audience": "Independent butcher shop owners, family-run butcheries, artisan meat suppliers",
+  "pain_points": [
+    "Butcher paper and trays are used in very high volumes daily",
+    "Meat packaging must prevent leaks and maintain hygiene",
+    "Carrier bags need to be sturdy enough for heavy meat purchases",
+    "Christmas and Easter peaks require significant advance ordering"
+  ],
+  "top_products": ["bags-and-wraps", "supplies-and-essentials", "hot-food", "tableware"],
+  "compliance_concerns": ["Food Information Regulations (weight, origin, best-before)", "Single-use carrier bag charge (minimum 10p)"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium (3,000–8,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/cake-shops.json
+++ b/lib/data/pseo/niches/cake-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "cake-shops",
+  "name": "Cake Shops",
+  "audience": "Cake shop owners, custom cake businesses, celebration cake bakers",
+  "pain_points": [
+    "Large cake boxes must be sturdy enough to transport safely",
+    "Variety of cake sizes means stocking multiple box dimensions",
+    "Cupcake inserts and individual cake containers add complexity",
+    "Customers expect premium unboxing experiences for celebration cakes"
+  ],
+  "top_products": ["cold-food-and-salads", "bags-and-wraps", "napkins", "supplies-and-essentials"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (nuts, eggs, dairy)", "Food hygiene rating display requirements"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/chicken-shop-franchises.json
+++ b/lib/data/pseo/niches/chicken-shop-franchises.json
@@ -1,0 +1,17 @@
+{
+  "slug": "chicken-shop-franchises",
+  "name": "Chicken Shop Franchises",
+  "audience": "Fried chicken franchise operators, chicken shop chain managers, branded chicken restaurant owners",
+  "pain_points": [
+    "Grease-proof packaging is essential — fried food saturates cheap materials",
+    "Bucket and box packaging for sharing meals is a unique format requirement",
+    "High delivery volumes through apps demand tamper-evident packaging",
+    "Sides (fries, coleslaw, beans) each need separate containers"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Calorie labelling for chains with 250+ employees", "HFSS advertising restrictions for high-fat products"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Very large (20,000–80,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/chinese-takeaways.json
+++ b/lib/data/pseo/niches/chinese-takeaways.json
@@ -1,0 +1,17 @@
+{
+  "slug": "chinese-takeaways",
+  "name": "Chinese Takeaways",
+  "audience": "Chinese takeaway owners, Cantonese restaurant operators, family-run Chinese food businesses",
+  "pain_points": [
+    "Iconic containers are expected but sustainability rules are changing",
+    "Soy sauce, prawn crackers, and sides all need separate packaging",
+    "Leak-proof containers are essential for saucy dishes",
+    "High delivery volumes on Friday and Saturday nights strain stock"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "tableware", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (soy, shellfish, sesame)", "Single-use plastics ban — polystyrene containers"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–10,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/cinema-concessions.json
+++ b/lib/data/pseo/niches/cinema-concessions.json
@@ -1,0 +1,17 @@
+{
+  "slug": "cinema-concessions",
+  "name": "Cinema Concessions",
+  "audience": "Cinema concession managers, independent cinema operators, multiplex food service teams",
+  "pain_points": [
+    "Popcorn and nachos packaging must be easy to eat from in the dark",
+    "Drink cups need to fit standard cinema cup holders",
+    "Hot dog trays and combo meal packaging must be single-handed friendly",
+    "HFSS rules increasingly affect what can be promoted at point of sale"
+  ],
+  "top_products": ["cups-and-lids", "hot-food", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["HFSS display and promotion restrictions", "Plastic straw ban (England 2023)"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium-large (5,000–20,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/coffee-franchises.json
+++ b/lib/data/pseo/niches/coffee-franchises.json
@@ -1,0 +1,17 @@
+{
+  "slug": "coffee-franchises",
+  "name": "Coffee Franchises",
+  "audience": "Coffee franchise operators, multi-site café chain managers, branded coffee shop owners",
+  "pain_points": [
+    "Brand compliance requires specific cup designs and sizes across all locations",
+    "Huge cup volumes make even small per-unit savings significant",
+    "Latte levy discussions make reusable cup schemes a consideration",
+    "Seasonal promotional cups (Christmas, summer) require advance planning"
+  ],
+  "top_products": ["cups-and-lids", "straws", "napkins", "cold-food-and-salads"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "Potential latte levy / disposable cup charge", "Calorie labelling for chains with 250+ employees"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Very large (30,000–100,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/coffee-shops.json
+++ b/lib/data/pseo/niches/coffee-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "coffee-shops",
+  "name": "Coffee Shops",
+  "audience": "Independent café owners, small coffee shop chains, barista-led businesses",
+  "pain_points": [
+    "High cup volume = packaging is a significant cost line",
+    "Customer pressure to go eco / ditch single-use plastic",
+    "Branding matters — cups are walking adverts",
+    "Storage space is limited in most café back-of-house"
+  ],
+  "top_products": ["cups-and-lids", "straws", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "HFSS display restrictions for food"],
+  "order_frequency": "Monthly or bi-monthly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/convenience-stores.json
+++ b/lib/data/pseo/niches/convenience-stores.json
@@ -1,0 +1,17 @@
+{
+  "slug": "convenience-stores",
+  "name": "Convenience Stores",
+  "audience": "Convenience store owners, corner shop operators, newsagent-cum-food retailers",
+  "pain_points": [
+    "Limited shelf space means packaging must be compact to store",
+    "Hot food counters (pasties, sausage rolls) need warming-compatible packaging",
+    "Carrier bags are a significant ongoing cost post-charge legislation",
+    "Sandwich and meal deal packaging must comply with allergen rules"
+  ],
+  "top_products": ["bags-and-wraps", "hot-food", "cold-food-and-salads", "supplies-and-essentials"],
+  "compliance_concerns": ["Single-use carrier bag charge (minimum 10p)", "Natasha's Law allergen labelling for pre-packed food", "HFSS display restrictions"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/dark-kitchens.json
+++ b/lib/data/pseo/niches/dark-kitchens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "dark-kitchens",
+  "name": "Dark Kitchens",
+  "audience": "Dark kitchen operators, multi-brand delivery kitchen managers, cloud kitchen entrepreneurs",
+  "pain_points": [
+    "Running multiple virtual brands means stocking different packaging per brand",
+    "Packaging must survive 30+ minute delivery journeys without degrading",
+    "Speed of packing is critical during peak delivery hours",
+    "Cost per order is scrutinised — every penny of packaging affects unit economics"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "cold-food-and-salads", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for all pre-packed meals", "Food Standards Agency registration for each virtual brand"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium-large (5,000–20,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/deli-counters.json
+++ b/lib/data/pseo/niches/deli-counters.json
@@ -1,0 +1,17 @@
+{
+  "slug": "deli-counters",
+  "name": "Deli Counters",
+  "audience": "Delicatessen owners, artisan food shop operators, gourmet deli counter managers",
+  "pain_points": [
+    "Greaseproof and wax paper wrapping is used for every customer interaction",
+    "Cheese, meats, and olives each need different packaging solutions",
+    "Pre-packed items for grab-and-go need allergen-compliant labelling",
+    "Premium products demand packaging that signals quality"
+  ],
+  "top_products": ["bags-and-wraps", "cold-food-and-salads", "supplies-and-essentials", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed deli items", "Food Information Regulations (weight and ingredient listing)"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/dessert-cafes.json
+++ b/lib/data/pseo/niches/dessert-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "dessert-cafes",
+  "name": "Dessert Cafés",
+  "audience": "Dessert café owners, waffles and crepes businesses, late-night dessert spots",
+  "pain_points": [
+    "Instagram-worthy presentation drives packaging choices",
+    "Sticky, saucy desserts need leak-proof containers",
+    "Late-night trade means high weekend volumes",
+    "Wide variety of dessert types requires multiple packaging formats"
+  ],
+  "top_products": ["cold-food-and-salads", "cups-and-lids", "napkins", "tableware"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (nuts, dairy, gluten)", "HFSS display restrictions for high-sugar products"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–4,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/event-caterers.json
+++ b/lib/data/pseo/niches/event-caterers.json
@@ -1,0 +1,17 @@
+{
+  "slug": "event-caterers",
+  "name": "Event Caterers",
+  "audience": "Corporate event caterers, large-scale catering companies, conference food service providers",
+  "pain_points": [
+    "Large orders needed quickly for one-off events",
+    "Different events demand different packaging — buffets, boxed lunches, finger food",
+    "Clients increasingly specify compostable or plastic-free packaging in tenders",
+    "Leftover stock from over-ordering ties up cash"
+  ],
+  "top_products": ["tableware", "hot-food", "cold-food-and-salads", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for boxed meals", "Health and safety requirements for large-scale events"],
+  "order_frequency": "Weekly (during event season)",
+  "avg_order_size": "Large (10,000–50,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/farm-shops.json
+++ b/lib/data/pseo/niches/farm-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "farm-shops",
+  "name": "Farm Shops",
+  "audience": "Farm shop owners, rural retail operators, farm-to-fork businesses with on-site shops",
+  "pain_points": [
+    "Artisan and homemade products need packaging that reflects quality",
+    "Wide product range (jams, pies, cheeses, baked goods) means many packaging formats",
+    "Seasonal produce peaks create variable packaging demand",
+    "Customers expect brown paper and natural-look packaging to match the farm brand"
+  ],
+  "top_products": ["bags-and-wraps", "cold-food-and-salads", "hot-food", "supplies-and-essentials"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for all pre-packed items", "Food Information Regulations (weight, ingredients, origin)"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–4,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/festival-food-vendors.json
+++ b/lib/data/pseo/niches/festival-food-vendors.json
@@ -1,0 +1,17 @@
+{
+  "slug": "festival-food-vendors",
+  "name": "Festival Food Vendors",
+  "audience": "Music festival food traders, outdoor event food vendors, summer festival caterers",
+  "pain_points": [
+    "Most festivals now mandate compostable-only packaging",
+    "Massive volumes needed for short trading windows (2–5 days)",
+    "No refrigeration on-site — packaging must suit ambient storage",
+    "Eat-while-standing format means packaging must be sturdy and one-handed"
+  ],
+  "top_products": ["hot-food", "cups-and-lids", "napkins", "tableware"],
+  "compliance_concerns": ["Festival compostable packaging mandates", "Temporary event food registration with local authority"],
+  "order_frequency": "Seasonal (bulk orders before each festival)",
+  "avg_order_size": "Large (10,000–30,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/fish-and-chip-shops.json
+++ b/lib/data/pseo/niches/fish-and-chip-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "fish-and-chip-shops",
+  "name": "Fish & Chip Shops",
+  "audience": "Traditional chippy owners, seaside fish and chip businesses, family-run takeaways",
+  "pain_points": [
+    "Grease-proof wrapping paper is used in huge volumes",
+    "Transition from polystyrene trays to sustainable alternatives is costly",
+    "Wooden chip forks and cutlery are now expected instead of plastic",
+    "Vinegar and sauce sachets create additional packaging waste"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "tableware", "supplies-and-essentials"],
+  "compliance_concerns": ["Single-use plastics ban — polystyrene food containers", "Food hygiene rating display requirements"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/fishmongers.json
+++ b/lib/data/pseo/niches/fishmongers.json
@@ -1,0 +1,17 @@
+{
+  "slug": "fishmongers",
+  "name": "Fishmongers",
+  "audience": "Independent fishmonger shop owners, fish market stallholders, fresh seafood retailers",
+  "pain_points": [
+    "Wrapping paper must be moisture-resistant and odour-containing",
+    "Carrier bags must handle wet, heavy products without tearing",
+    "Ice and drainage mean packaging gets wet — durability is key",
+    "Shellfish and prepared fish need different packaging formats"
+  ],
+  "top_products": ["bags-and-wraps", "supplies-and-essentials", "cold-food-and-salads", "tableware"],
+  "compliance_concerns": ["Food Information Regulations (species, origin, catch method)", "Allergen labelling for shellfish and crustaceans"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/food-trucks.json
+++ b/lib/data/pseo/niches/food-trucks.json
@@ -1,0 +1,17 @@
+{
+  "slug": "food-trucks",
+  "name": "Food Trucks",
+  "audience": "Food truck operators, mobile catering businesses, street food entrepreneurs",
+  "pain_points": [
+    "Extremely limited storage space — packaging must be compact and stackable",
+    "Everything is takeaway — no dine-in means 100% packaging dependency",
+    "Must cater to different events with varying customer volumes",
+    "Weather exposure means packaging must hold up in wind and rain"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "napkins", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed items", "Street trading licence requirements vary by council"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–4,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/garden-centre-cafes.json
+++ b/lib/data/pseo/niches/garden-centre-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "garden-centre-cafes",
+  "name": "Garden Centre Cafés",
+  "audience": "Garden centre café managers, destination garden centre operators, nursery restaurant teams",
+  "pain_points": [
+    "Older customer demographic expects proper tableware, even disposable",
+    "Scone and cake trade means high napkin and cake box usage",
+    "Weekend and bank holiday peaks require buffer stock",
+    "Eco-conscious gardening customers expect green packaging choices"
+  ],
+  "top_products": ["tableware", "cups-and-lids", "napkins", "cold-food-and-salads"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed cakes and sandwiches", "Food hygiene rating display requirements"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/gastro-pubs.json
+++ b/lib/data/pseo/niches/gastro-pubs.json
@@ -1,0 +1,17 @@
+{
+  "slug": "gastro-pubs",
+  "name": "Gastro Pubs",
+  "audience": "Gastro pub owners, premium pub dining operators, chef-led pub restaurants",
+  "pain_points": [
+    "Takeaway packaging must match the premium dining experience",
+    "Seasonal menus mean packaging needs change throughout the year",
+    "Delivery apps demand consistent, professional packaging",
+    "Sustainability credentials matter to the foodie customer base"
+  ],
+  "top_products": ["hot-food", "cold-food-and-salads", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling", "Calorie labelling for chains with 250+ employees"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–4,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/gelato-shops.json
+++ b/lib/data/pseo/niches/gelato-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "gelato-shops",
+  "name": "Gelato Shops",
+  "audience": "Artisan gelato makers, Italian-style ice cream businesses, premium frozen dessert shops",
+  "pain_points": [
+    "Premium positioning demands high-quality, visually appealing cups and tubs",
+    "Gelato containers need to be freezer-safe for take-home pints",
+    "Tasting spoons used in high volumes — plastic ban means sourcing alternatives",
+    "Seasonal demand swings make stock planning difficult"
+  ],
+  "top_products": ["cups-and-lids", "tableware", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Single-use plastics ban — plastic spoons and tasting sticks", "Natasha's Law allergen labelling (dairy, nuts, gluten in cones)"],
+  "order_frequency": "Monthly (seasonal peaks in summer)",
+  "avg_order_size": "Small (500–3,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/ghost-kitchens.json
+++ b/lib/data/pseo/niches/ghost-kitchens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "ghost-kitchens",
+  "name": "Ghost Kitchens",
+  "audience": "Ghost kitchen operators, virtual restaurant owners, delivery-only kitchen businesses",
+  "pain_points": [
+    "100% delivery means packaging IS the customer experience",
+    "Multiple brands operating from one kitchen need distinct packaging",
+    "Delivery app ratings depend on food arriving in perfect condition",
+    "No dine-in revenue to subsidise packaging costs"
+  ],
+  "top_products": ["hot-food", "cold-food-and-salads", "bags-and-wraps", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for all delivered meals", "Food hygiene rating display on delivery platforms"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium-large (5,000–20,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/gluten-free-cafes.json
+++ b/lib/data/pseo/niches/gluten-free-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "gluten-free-cafes",
+  "name": "Gluten-Free Cafés",
+  "audience": "Gluten-free café owners, coeliac-friendly bakery operators, free-from food businesses",
+  "pain_points": [
+    "Cross-contamination risk means dedicated packaging storage is essential",
+    "Allergen labelling is the single most critical compliance concern",
+    "Customers pay premium prices and expect premium packaging to match",
+    "Niche market means smaller volumes but highly loyal repeat customers"
+  ],
+  "top_products": ["cold-food-and-salads", "bags-and-wraps", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (gluten-free claims must be substantiated)", "Food Information Regulations — 'free from' labelling rules"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/grocery-stores.json
+++ b/lib/data/pseo/niches/grocery-stores.json
@@ -1,0 +1,17 @@
+{
+  "slug": "grocery-stores",
+  "name": "Grocery Stores",
+  "audience": "Independent grocery store owners, neighbourhood shop operators, ethnic grocery retailers",
+  "pain_points": [
+    "Carrier bag charge means stocking paper and reusable alternatives",
+    "Fresh produce bags are high-volume consumables",
+    "Deli and hot food counters need separate packaging ranges",
+    "Competing with supermarkets on price means packaging costs must be low"
+  ],
+  "top_products": ["bags-and-wraps", "supplies-and-essentials", "cold-food-and-salads", "hot-food"],
+  "compliance_concerns": ["Single-use carrier bag charge (minimum 10p)", "Food Information Regulations for pre-packed goods"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–10,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/halal-restaurants.json
+++ b/lib/data/pseo/niches/halal-restaurants.json
@@ -1,0 +1,17 @@
+{
+  "slug": "halal-restaurants",
+  "name": "Halal Restaurants",
+  "audience": "Halal restaurant owners, halal-certified food businesses, Muslim community food operators",
+  "pain_points": [
+    "Packaging supply chain must not be contaminated with non-halal materials",
+    "Large family-size portions are common — need bigger containers",
+    "Delivery trade is significant, especially during Ramadan",
+    "Branding must communicate halal credentials clearly"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "cups-and-lids", "cold-food-and-salads"],
+  "compliance_concerns": ["Halal certification display requirements", "Natasha's Law allergen labelling"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–8,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/health-food-cafes.json
+++ b/lib/data/pseo/niches/health-food-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "health-food-cafes",
+  "name": "Health Food Cafés",
+  "audience": "Health food café owners, wellness kitchen operators, clean eating restaurant businesses",
+  "pain_points": [
+    "Brand ethos demands visibly sustainable, natural-looking packaging",
+    "Salad bowls and poké containers are high-volume daily items",
+    "Customers photograph their food — packaging is part of the brand",
+    "Nutritional labelling and allergen info expected on every pre-packed item"
+  ],
+  "top_products": ["cold-food-and-salads", "cups-and-lids", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling", "Nutritional and health claims regulations (EC 1924/2006 retained)"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/hospital-cafeterias.json
+++ b/lib/data/pseo/niches/hospital-cafeterias.json
@@ -1,0 +1,17 @@
+{
+  "slug": "hospital-cafeterias",
+  "name": "Hospital Cafeterias",
+  "audience": "NHS trust catering managers, private hospital food service operators, hospital café franchisees",
+  "pain_points": [
+    "24/7 operation means constant packaging consumption",
+    "NHS procurement frameworks add bureaucracy to purchasing",
+    "Hygiene standards are exceptionally high — sealed packaging preferred",
+    "Staff, visitors, and patients all have different needs and budgets"
+  ],
+  "top_products": ["hot-food", "cups-and-lids", "cold-food-and-salads", "tableware"],
+  "compliance_concerns": ["NHS sustainability targets (net zero by 2040)", "Natasha's Law allergen labelling", "CQC food safety requirements"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Large (10,000–25,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/hotel-bars.json
+++ b/lib/data/pseo/niches/hotel-bars.json
@@ -1,0 +1,17 @@
+{
+  "slug": "hotel-bars",
+  "name": "Hotel Bars",
+  "audience": "Hotel bar managers, boutique hotel cocktail bar operators, hotel lounge managers",
+  "pain_points": [
+    "Cocktail straws and stirrers must now be non-plastic alternatives",
+    "Napkins and coasters are high-volume consumables at bar service",
+    "Room service drinks need spill-proof cups and lids",
+    "Premium feel is essential — cheap packaging undermines the hotel brand"
+  ],
+  "top_products": ["cups-and-lids", "straws", "napkins", "supplies-and-essentials"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "Licensing Act requirements for food service at bars"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/hotel-restaurants.json
+++ b/lib/data/pseo/niches/hotel-restaurants.json
@@ -1,0 +1,17 @@
+{
+  "slug": "hotel-restaurants",
+  "name": "Hotel Restaurants",
+  "audience": "Hotel F&B managers, boutique hotel restaurant operators, hotel chain catering directors",
+  "pain_points": [
+    "Room service packaging must feel premium and keep food warm",
+    "Breakfast buffets need a range of disposable options for busy mornings",
+    "Conference and event catering requires bulk disposable tableware",
+    "Brand consistency across packaging reinforces hotel identity"
+  ],
+  "top_products": ["hot-food", "tableware", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for buffet items", "Tourism sector sustainability certifications (Green Tourism)"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium-large (5,000–20,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/ice-cream-parlours.json
+++ b/lib/data/pseo/niches/ice-cream-parlours.json
@@ -1,0 +1,17 @@
+{
+  "slug": "ice-cream-parlours",
+  "name": "Ice Cream Parlours",
+  "audience": "Ice cream shop owners, gelato and soft-serve operators, seaside parlour businesses",
+  "pain_points": [
+    "Seasonal trade means demand spikes massively in summer",
+    "Tubs, cones, and cups all need different packaging solutions",
+    "Spoons must now be non-plastic — wooden or paper alternatives required",
+    "Takeaway pints and family tubs need secure, insulated packaging"
+  ],
+  "top_products": ["cups-and-lids", "tableware", "napkins", "supplies-and-essentials"],
+  "compliance_concerns": ["Single-use plastics ban — plastic spoons and stirrers", "Natasha's Law allergen labelling (dairy, nuts)"],
+  "order_frequency": "Monthly (seasonal peaks in summer)",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/independent-cafes.json
+++ b/lib/data/pseo/niches/independent-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "independent-cafes",
+  "name": "Independent Cafés",
+  "audience": "Owner-operated cafés, lifestyle café businesses, brunch spots",
+  "pain_points": [
+    "Tight margins make every packaging penny count",
+    "Need to stand out visually against chain competitors",
+    "Customers expect compostable or recyclable packaging",
+    "Juggling dine-in tableware and takeaway packaging simultaneously"
+  ],
+  "top_products": ["cups-and-lids", "cold-food-and-salads", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "Natasha's Law allergen labelling for pre-packed food"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/indian-takeaways.json
+++ b/lib/data/pseo/niches/indian-takeaways.json
@@ -1,0 +1,17 @@
+{
+  "slug": "indian-takeaways",
+  "name": "Indian Takeaways",
+  "audience": "Indian restaurant and takeaway owners, curry house operators, family-run Indian food businesses",
+  "pain_points": [
+    "Curries and sauces demand leak-proof containers — spills ruin deliveries",
+    "Multiple dish orders need a range of container sizes",
+    "Foil containers are traditional but customers now expect eco options",
+    "Rice, naan, and sides all need separate packaging formats"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "tableware", "supplies-and-essentials"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (nut allergies critical)", "Food hygiene rating display requirements"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–10,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/juice-bars.json
+++ b/lib/data/pseo/niches/juice-bars.json
@@ -1,0 +1,17 @@
+{
+  "slug": "juice-bars",
+  "name": "Juice Bars",
+  "audience": "Fresh juice bar owners, cold-pressed juice businesses, health drink retailers",
+  "pain_points": [
+    "Health-conscious brand image demands eco-friendly packaging",
+    "Juice leaks are a constant complaint — lids and seals must be reliable",
+    "High turnover of cups during peak hours",
+    "Customers often want to see the product — clear cups are preferred"
+  ],
+  "top_products": ["cups-and-lids", "straws", "cold-food-and-salads", "napkins"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "Natasha's Law allergen labelling for pre-packed juices"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/kebab-shops.json
+++ b/lib/data/pseo/niches/kebab-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "kebab-shops",
+  "name": "Kebab Shops",
+  "audience": "Kebab shop owners, late-night takeaway operators, döner and shish businesses",
+  "pain_points": [
+    "Need packaging that handles hot, saucy food without leaking",
+    "Late-night trade means high-volume, fast-paced service",
+    "Polystyrene ban is forcing a switch to more expensive alternatives",
+    "Pitta wraps and salad boxes need different container types"
+  ],
+  "top_products": ["hot-food", "bags-and-wraps", "cold-food-and-salads", "napkins"],
+  "compliance_concerns": ["Single-use plastics ban — polystyrene containers", "Calorie labelling regulations for larger chains"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (2,000–6,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/kosher-kitchens.json
+++ b/lib/data/pseo/niches/kosher-kitchens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "kosher-kitchens",
+  "name": "Kosher Kitchens",
+  "audience": "Kosher restaurant operators, kosher catering businesses, Jewish community kitchen managers",
+  "pain_points": [
+    "Meat and dairy packaging must be kept strictly separate",
+    "Kosher certification requirements extend to packaging materials",
+    "Smaller customer base means lower volumes but higher specificity",
+    "Shabbat and holiday catering creates seasonal demand spikes"
+  ],
+  "top_products": ["hot-food", "cold-food-and-salads", "tableware", "bags-and-wraps"],
+  "compliance_concerns": ["Kosher certification (Beth Din) requirements for food contact materials", "Natasha's Law allergen labelling"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/market-traders.json
+++ b/lib/data/pseo/niches/market-traders.json
@@ -1,0 +1,17 @@
+{
+  "slug": "market-traders",
+  "name": "Market Traders",
+  "audience": "Food market stallholders, farmers market vendors, borough market traders",
+  "pain_points": [
+    "Markets often mandate compostable or recyclable packaging only",
+    "Need packaging that works for sampling as well as full portions",
+    "Setup and teardown time means packaging must be quick to assemble",
+    "Variable weekly income makes cost control on packaging critical"
+  ],
+  "top_products": ["bags-and-wraps", "hot-food", "cold-food-and-salads", "napkins"],
+  "compliance_concerns": ["Market-specific sustainability requirements", "Natasha's Law allergen labelling for pre-packed goods"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/meal-kit-companies.json
+++ b/lib/data/pseo/niches/meal-kit-companies.json
@@ -1,0 +1,17 @@
+{
+  "slug": "meal-kit-companies",
+  "name": "Meal Kit Companies",
+  "audience": "Meal kit delivery startups, recipe box companies, ingredient kit businesses",
+  "pain_points": [
+    "Each kit contains multiple components needing individual packaging",
+    "Insulated and temperature-controlled outer packaging is essential",
+    "Sustainability is a core brand value — customers reject excess plastic",
+    "Scale-up from hundreds to thousands of kits per week strains packaging supply"
+  ],
+  "top_products": ["bags-and-wraps", "cold-food-and-salads", "supplies-and-essentials", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for each component", "Food Information Regulations (full ingredient listing per item)"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Large (10,000–50,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/meal-prep-businesses.json
+++ b/lib/data/pseo/niches/meal-prep-businesses.json
@@ -1,0 +1,17 @@
+{
+  "slug": "meal-prep-businesses",
+  "name": "Meal Prep Businesses",
+  "audience": "Meal prep entrepreneurs, fitness meal delivery operators, weekly meal plan companies",
+  "pain_points": [
+    "Microwave-safe and freezer-safe containers are non-negotiable",
+    "Hundreds of identical containers needed weekly — consistency matters",
+    "Labelling with macros, ingredients, and allergens on every container",
+    "Containers must stack neatly for fridge storage by the customer"
+  ],
+  "top_products": ["hot-food", "cold-food-and-salads", "supplies-and-essentials", "bags-and-wraps"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for every pre-packed meal", "Food Information Regulations (nutritional info, ingredients)"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium-large (5,000–15,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/museum-cafes.json
+++ b/lib/data/pseo/niches/museum-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "museum-cafes",
+  "name": "Museum Cafés",
+  "audience": "Museum café operators, gallery restaurant managers, heritage site catering teams",
+  "pain_points": [
+    "Institutional sustainability policies often mandate eco-friendly packaging",
+    "Tourist peaks in summer and school holidays strain stock levels",
+    "Must maintain a quality feel consistent with the cultural venue brand",
+    "Gift shop integration means cake boxes and food gifts need attractive packaging"
+  ],
+  "top_products": ["cups-and-lids", "cold-food-and-salads", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Public body sustainability targets", "Natasha's Law allergen labelling for pre-packed café items"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/noodle-bars.json
+++ b/lib/data/pseo/niches/noodle-bars.json
@@ -1,0 +1,17 @@
+{
+  "slug": "noodle-bars",
+  "name": "Noodle Bars",
+  "audience": "Noodle bar owners, ramen shop operators, Asian street food businesses",
+  "pain_points": [
+    "Hot soup and broth containers must be completely leak-proof",
+    "Chopsticks and spoons are essential add-ons with each order",
+    "Steam from hot noodles can weaken cheap packaging",
+    "Fast casual service means packaging must be grab-and-go friendly"
+  ],
+  "top_products": ["hot-food", "cups-and-lids", "tableware", "bags-and-wraps"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (soy, gluten, shellfish)", "Single-use plastics ban — polystyrene soup containers"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium (2,000–6,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/office-canteens.json
+++ b/lib/data/pseo/niches/office-canteens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "office-canteens",
+  "name": "Office Canteens",
+  "audience": "Corporate catering managers, workplace canteen operators, contract caterers serving offices",
+  "pain_points": [
+    "Corporate ESG commitments drive sustainable packaging mandates",
+    "Lunchtime rush requires fast, efficient grab-and-go packaging",
+    "Multiple floors or buildings may need separate stock points",
+    "Companies want branded or co-branded packaging for staff restaurants"
+  ],
+  "top_products": ["cold-food-and-salads", "hot-food", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed meals", "Corporate ESG and sustainability reporting requirements"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium-large (5,000–15,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/patisseries.json
+++ b/lib/data/pseo/niches/patisseries.json
@@ -1,0 +1,17 @@
+{
+  "slug": "patisseries",
+  "name": "Patisseries",
+  "audience": "French patisserie owners, artisan pastry chefs, premium cake and pastry businesses",
+  "pain_points": [
+    "Delicate pastries demand rigid, protective packaging",
+    "Premium brand perception requires high-quality presentation boxes",
+    "Individual pastry portions need elegant single-serve containers",
+    "Gift boxing and ribbon options are expected by customers"
+  ],
+  "top_products": ["cold-food-and-salads", "bags-and-wraps", "napkins", "tableware"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (nuts, dairy, gluten)", "Food Information Regulations (ingredient listing)"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–2,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/pizza-franchises.json
+++ b/lib/data/pseo/niches/pizza-franchises.json
@@ -1,0 +1,17 @@
+{
+  "slug": "pizza-franchises",
+  "name": "Pizza Franchises",
+  "audience": "Pizza franchise operators, multi-site pizza delivery managers, branded pizza chain owners",
+  "pain_points": [
+    "Pizza boxes are the highest-volume single packaging item by far",
+    "Franchisor branding requirements dictate box design and print specs",
+    "Delivery logistics demand sturdy, stackable boxes that resist grease",
+    "Side orders, dips, and desserts all need additional packaging formats"
+  ],
+  "top_products": ["pizza-boxes", "hot-food", "bags-and-wraps", "cups-and-lids"],
+  "compliance_concerns": ["Calorie labelling for chains with 250+ employees", "Natasha's Law allergen labelling for pre-packed sides"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Very large (30,000–100,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/pizza-takeaways.json
+++ b/lib/data/pseo/niches/pizza-takeaways.json
@@ -1,0 +1,17 @@
+{
+  "slug": "pizza-takeaways",
+  "name": "Pizza Takeaways",
+  "audience": "Independent pizza shop owners, takeaway-only pizza businesses, late-night pizza operators",
+  "pain_points": [
+    "Pizza boxes are the single biggest packaging expense",
+    "Grease resistance is non-negotiable — cheap boxes fall apart",
+    "Delivery drivers need stackable, sturdy packaging",
+    "Side items (garlic bread, dips) need separate containers"
+  ],
+  "top_products": ["pizza-boxes", "hot-food", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed items", "Food hygiene rating display requirements"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Medium (3,000–10,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/pub-kitchens.json
+++ b/lib/data/pseo/niches/pub-kitchens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "pub-kitchens",
+  "name": "Pub Kitchens",
+  "audience": "Pub landlords with food service, pub kitchen managers, traditional pub grub operators",
+  "pain_points": [
+    "Takeaway trade grew post-COVID and now needs proper packaging",
+    "Sunday roast and pie packaging must keep food hot during delivery",
+    "Beer garden service in summer needs disposable plates and cutlery",
+    "Budget is tight — food is often secondary to drinks revenue"
+  ],
+  "top_products": ["hot-food", "tableware", "bags-and-wraps", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed pub meals", "Calorie labelling for pubs with 250+ employees"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "low",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/sandwich-shops.json
+++ b/lib/data/pseo/niches/sandwich-shops.json
@@ -1,0 +1,17 @@
+{
+  "slug": "sandwich-shops",
+  "name": "Sandwich Shops",
+  "audience": "Independent sandwich shop owners, lunch trade specialists, meal deal providers",
+  "pain_points": [
+    "Lunchtime rush means pre-packing sandwiches — Natasha's Law compliance is critical",
+    "Sandwich wedge containers must display the product attractively",
+    "Meal deal combos (sandwich + drink + snack) need coordinated packaging",
+    "Margins are tight on lunch trade — every penny on packaging matters"
+  ],
+  "top_products": ["cold-food-and-salads", "bags-and-wraps", "cups-and-lids", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed sandwiches", "HFSS display restrictions for meal deals"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/school-canteens.json
+++ b/lib/data/pseo/niches/school-canteens.json
@@ -1,0 +1,17 @@
+{
+  "slug": "school-canteens",
+  "name": "School Canteens",
+  "audience": "School catering managers, academy trust procurement teams, school meal providers",
+  "pain_points": [
+    "Strict budgets set by local authorities or academy trusts",
+    "Allergen management is critical with young children",
+    "Must balance cost with government healthy eating standards",
+    "High volume of single-use items for packed lunch and grab-and-go options"
+  ],
+  "top_products": ["hot-food", "cold-food-and-salads", "cups-and-lids", "tableware"],
+  "compliance_concerns": ["School Food Standards (nutrient-based)", "Natasha's Law allergen labelling", "HFSS restrictions in school settings"],
+  "order_frequency": "Monthly (term-time only)",
+  "avg_order_size": "Medium-large (5,000–15,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "low"
+}

--- a/lib/data/pseo/niches/smoothie-bars.json
+++ b/lib/data/pseo/niches/smoothie-bars.json
@@ -1,0 +1,17 @@
+{
+  "slug": "smoothie-bars",
+  "name": "Smoothie Bars",
+  "audience": "Smoothie bar operators, health food drink vendors, gym-adjacent juice shops",
+  "pain_points": [
+    "Thick smoothies need sturdy cups and wide straws",
+    "Brand identity tied to wellness — packaging must match the ethos",
+    "Peak morning and lunchtime rushes require fast, reliable packaging",
+    "Acai bowls and smoothie bowls need separate cold food containers"
+  ],
+  "top_products": ["cups-and-lids", "straws", "cold-food-and-salads", "napkins"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "HFSS display restrictions for high-sugar smoothies"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–4,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/smoothie-franchises.json
+++ b/lib/data/pseo/niches/smoothie-franchises.json
@@ -1,0 +1,17 @@
+{
+  "slug": "smoothie-franchises",
+  "name": "Smoothie Franchises",
+  "audience": "Smoothie franchise operators, multi-site smoothie bar managers, health drink chain owners",
+  "pain_points": [
+    "Franchisor mandates specific cup sizes and branding — limited flexibility",
+    "Multi-site ordering needs centralised procurement to maintain consistency",
+    "High throughput during commuter and lunchtime peaks",
+    "National brand reputation requires consistent packaging quality across all sites"
+  ],
+  "top_products": ["cups-and-lids", "straws", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "HFSS display restrictions for high-sugar drinks", "Calorie labelling for chains with 250+ employees"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Large (10,000–30,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/sports-stadium-concessions.json
+++ b/lib/data/pseo/niches/sports-stadium-concessions.json
@@ -1,0 +1,17 @@
+{
+  "slug": "sports-stadium-concessions",
+  "name": "Sports Stadium Concessions",
+  "audience": "Stadium catering managers, sports venue food operators, matchday concession stand teams",
+  "pain_points": [
+    "Extreme volume spikes on matchdays — tens of thousands served in 90 minutes",
+    "Speed of service is critical so packaging must be pre-assembled or easy to open",
+    "Pies, burgers, and hot dogs need packaging that fans can eat from in their seats",
+    "Club branding on cups and food packaging is a revenue opportunity"
+  ],
+  "top_products": ["hot-food", "cups-and-lids", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Licensing Act requirements for alcohol service", "Natasha's Law allergen labelling for pre-packed pies"],
+  "order_frequency": "Weekly (matchday schedule)",
+  "avg_order_size": "Very large (30,000–100,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/street-food-stalls.json
+++ b/lib/data/pseo/niches/street-food-stalls.json
@@ -1,0 +1,17 @@
+{
+  "slug": "street-food-stalls",
+  "name": "Street Food Stalls",
+  "audience": "Street food vendors, pop-up food stall operators, weekend market food traders",
+  "pain_points": [
+    "No running water at most pitches — wet wipes and napkins are essential",
+    "Packaging must be easy to eat from while standing or walking",
+    "Events often require compostable-only packaging",
+    "Unpredictable footfall makes ordering the right quantity difficult"
+  ],
+  "top_products": ["hot-food", "napkins", "bags-and-wraps", "tableware"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed items", "Event-specific compostable packaging mandates"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–3,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/sushi-restaurants.json
+++ b/lib/data/pseo/niches/sushi-restaurants.json
@@ -1,0 +1,17 @@
+{
+  "slug": "sushi-restaurants",
+  "name": "Sushi Restaurants",
+  "audience": "Sushi bar owners, Japanese restaurant operators, sushi delivery businesses",
+  "pain_points": [
+    "Presentation is paramount — packaging must showcase the product",
+    "Sushi platters need compartmentalised trays with clear lids",
+    "Soy sauce sachets and chopsticks add to per-order packaging cost",
+    "Cold chain integrity means packaging must maintain freshness"
+  ],
+  "top_products": ["cold-food-and-salads", "tableware", "bags-and-wraps", "supplies-and-essentials"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (fish, soy, sesame)", "Food hygiene rating display requirements"],
+  "order_frequency": "Weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/tea-rooms.json
+++ b/lib/data/pseo/niches/tea-rooms.json
@@ -1,0 +1,17 @@
+{
+  "slug": "tea-rooms",
+  "name": "Tea Rooms",
+  "audience": "Traditional tea room owners, heritage café operators, afternoon tea businesses",
+  "pain_points": [
+    "Presentation is everything — packaging must feel premium",
+    "Seasonal tourist trade means unpredictable order volumes",
+    "Cake and pastry packaging needs to protect delicate items",
+    "Many customers are older and expect traditional, non-plastic materials"
+  ],
+  "top_products": ["tableware", "napkins", "cold-food-and-salads", "cups-and-lids"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed food", "Food hygiene rating display requirements"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small (500–1,500 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/theatre-cafes.json
+++ b/lib/data/pseo/niches/theatre-cafes.json
@@ -1,0 +1,17 @@
+{
+  "slug": "theatre-cafes",
+  "name": "Theatre Cafés",
+  "audience": "Theatre café and bar managers, performing arts venue caterers, interval refreshment operators",
+  "pain_points": [
+    "Interval service must be lightning fast — 15 minutes to serve hundreds",
+    "Ice cream tubs and pre-poured drinks dominate interval trade",
+    "Premium venue feel demands quality packaging, not cheap disposables",
+    "Matinee and evening shows create two distinct service peaks per day"
+  ],
+  "top_products": ["cups-and-lids", "cold-food-and-salads", "napkins", "tableware"],
+  "compliance_concerns": ["Plastic straw ban (England 2023)", "Natasha's Law allergen labelling for pre-packed snacks"],
+  "order_frequency": "Monthly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "medium",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/university-cafeterias.json
+++ b/lib/data/pseo/niches/university-cafeterias.json
@@ -1,0 +1,17 @@
+{
+  "slug": "university-cafeterias",
+  "name": "University Cafeterias",
+  "audience": "University catering managers, student union food outlets, campus café operators",
+  "pain_points": [
+    "Student population is highly vocal about sustainability",
+    "Multiple outlets across campus need consistent packaging",
+    "Term-time peaks and holiday troughs make stock planning tricky",
+    "Price sensitivity among students demands affordable packaging solutions"
+  ],
+  "top_products": ["cups-and-lids", "hot-food", "cold-food-and-salads", "napkins"],
+  "compliance_concerns": ["Natasha's Law allergen labelling", "University sustainability charter commitments", "Plastic-free campus pledges"],
+  "order_frequency": "Bi-weekly (term-time)",
+  "avg_order_size": "Large (10,000–30,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/niches/vegan-restaurants.json
+++ b/lib/data/pseo/niches/vegan-restaurants.json
@@ -1,0 +1,17 @@
+{
+  "slug": "vegan-restaurants",
+  "name": "Vegan Restaurants",
+  "audience": "Vegan restaurant owners, plant-based café operators, fully vegan food businesses",
+  "pain_points": [
+    "Packaging must be fully plant-based — no animal-derived materials allowed",
+    "Customers are extremely eco-conscious and will call out greenwashing",
+    "Compostable certification (e.g. EN 13432) is often expected, not optional",
+    "Takeaway salad bowls and cold food containers are high-volume items"
+  ],
+  "top_products": ["cold-food-and-salads", "hot-food", "cups-and-lids", "bags-and-wraps"],
+  "compliance_concerns": ["Natasha's Law allergen labelling (soy, nuts, sesame common in vegan food)", "Compostable packaging certification claims must be substantiated"],
+  "order_frequency": "Bi-weekly",
+  "avg_order_size": "Small-medium (1,000–5,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "high"
+}

--- a/lib/data/pseo/niches/wedding-caterers.json
+++ b/lib/data/pseo/niches/wedding-caterers.json
@@ -1,0 +1,17 @@
+{
+  "slug": "wedding-caterers",
+  "name": "Wedding Caterers",
+  "audience": "Wedding catering companies, bespoke event caterers, bridal food service providers",
+  "pain_points": [
+    "Every wedding is different — packaging needs vary per event",
+    "Presentation must be immaculate for the most photographed meal of the year",
+    "Canape trays, dessert boxes, and favour packaging all needed",
+    "Seasonal peaks (May–September) require advance bulk ordering"
+  ],
+  "top_products": ["tableware", "cold-food-and-salads", "napkins", "bags-and-wraps"],
+  "compliance_concerns": ["Natasha's Law allergen labelling for pre-packed canapés", "Food safety for outdoor and marquee events"],
+  "order_frequency": "Seasonal (monthly during peak season)",
+  "avg_order_size": "Medium (2,000–8,000 units per SKU)",
+  "sustainability_pressure": "high",
+  "branding_interest": "medium"
+}

--- a/lib/data/pseo/pages/for/coffee-shops.json
+++ b/lib/data/pseo/pages/for/coffee-shops.json
@@ -1,0 +1,81 @@
+{
+  "meta": {
+    "slug": "coffee-shops",
+    "business_type": "Coffee Shops",
+    "seo_title": "Packaging Supplies for Coffee Shops | Afida",
+    "seo_description": "Wholesale packaging for coffee shops: eco-friendly cups, lids, stirrers, napkins and bags. Free UK delivery over £100. Trusted by 500+ cafés.",
+    "keywords": ["coffee shop packaging", "disposable cups wholesale", "eco coffee cups", "takeaway cup supplier", "coffee shop supplies UK"]
+  },
+  "hero": {
+    "headline": "Packaging Built for Coffee Shops",
+    "subheadline": "Everything your café needs, from cup to carrier bag — eco-friendly, competitively priced, and delivered fast.",
+    "intro": "Running a coffee shop means going through packaging at speed. Cups, lids, stirrers, napkins, bags — they all add up, and they all matter. Your customers notice when the cup feels cheap, when the lid doesn't click properly, or when the bag rips on the walk home. That's why choosing the right packaging supplier isn't just a back-office decision — it affects how people experience your brand every single day. At Afida, we supply hundreds of UK coffee shops with high-quality, eco-friendly packaging at wholesale prices. Whether you're a single-site independent or a growing chain, we've got the range, the stock, and the delivery speed to keep your operation running without the stress of running out. Free delivery on orders over £100, next-day dispatch before 2pm, and a team that actually understands what coffee shops need."
+  },
+  "packaging_needs": [
+    {
+      "category": "Cups & Lids",
+      "why_it_matters": "Your cup is a walking advert. It's the first thing customers hold and the last thing they throw away. A good cup says quality — a bad one says corner-cutting.",
+      "recommended_products": ["single-wall-coffee-cups", "double-wall-coffee-cups", "sip-lids"],
+      "buying_tip": "Double-wall cups eliminate the need for sleeves, saving you money per serve. If you're doing high volumes, calculate the per-unit saving — it adds up fast over a month."
+    },
+    {
+      "category": "Straws & Stirrers",
+      "why_it_matters": "The UK plastic straw ban means you need compliant alternatives. Paper and bio-fibre straws are now the standard, and customers expect them.",
+      "recommended_products": ["paper-straws", "bio-fibre-straws", "wooden-stirrers"],
+      "buying_tip": "Bio-fibre straws last longer in drinks than standard paper straws. If you serve iced coffees or smoothies, they're worth the small premium."
+    },
+    {
+      "category": "Napkins",
+      "why_it_matters": "Napkins are one of those things nobody notices until they're missing. Keep dispensers stocked and quality consistent — recycled napkins work well and cost less.",
+      "recommended_products": ["recycled-napkins", "dispenser-napkins"],
+      "buying_tip": "Dispenser napkins reduce waste by 30% compared to open napkin holders. Customers take what they need instead of grabbing a fistful."
+    },
+    {
+      "category": "Bags & Carriers",
+      "why_it_matters": "Takeaway orders need bags that can handle hot cups without going soggy. A branded bag also extends your marketing reach beyond the shop door.",
+      "recommended_products": ["paper-carrier-bags", "kraft-bags"],
+      "buying_tip": "If you do a lot of takeaway, invest in bags with a flat base that can stand upright. It makes packing faster and reduces spills."
+    },
+    {
+      "category": "Food Packaging",
+      "why_it_matters": "Most coffee shops sell food too — sandwiches, pastries, cakes. You need packaging that keeps food fresh, looks clean, and fits your cabinet layout.",
+      "recommended_products": ["sandwich-wedges", "cake-boxes", "deli-containers"],
+      "buying_tip": "Clear-window sandwich wedges let customers see the filling without you needing to label everything. They also stack neatly in chiller displays."
+    }
+  ],
+  "sustainability_section": {
+    "intro": "Coffee shops face more sustainability pressure than almost any other food business. Customers see the cups piling up and they want to know you're doing something about it. Here's how Afida can help you make meaningful changes without blowing your budget.",
+    "options": [
+      { "name": "Vegware Compostable Cups", "benefit": "Made from plants, not plastic. Commercially compostable and EN 13432 certified — genuinely breaks down, not just greenwashing." },
+      { "name": "Recyclable Paper Cups", "benefit": "PE-free paper cups that go straight into standard paper recycling streams. No special waste collections needed." },
+      { "name": "Bio-Fibre Straws", "benefit": "Last longer in drinks than paper straws and are fully compostable. Customers won't complain about soggy straws." },
+      { "name": "Recycled Napkins", "benefit": "Made from 100% recycled paper. Same quality, significantly lower environmental footprint." }
+    ]
+  },
+  "faqs": [
+    {
+      "question": "What's the minimum order for coffee shop packaging?",
+      "answer": "There's no minimum order at Afida. You can order as little or as much as you need. However, orders over £100 (excl. VAT) qualify for free standard delivery across the UK mainland, so most coffee shops find it cost-effective to consolidate their orders to hit that threshold."
+    },
+    {
+      "question": "How quickly can you deliver to my coffee shop?",
+      "answer": "Orders placed before 2pm on a working day are dispatched the same day for next-day delivery. Standard delivery typically arrives within one to two working days. We hold good stock levels across our full range, so back-orders are rare and we'll always let you know upfront if something is temporarily out of stock."
+    },
+    {
+      "question": "Can I get my coffee cups branded with my logo?",
+      "answer": "Yes. We offer custom branding on double-wall coffee cups starting from just 1,000 units. No setup fees, UK production, and delivered in around 20 business days. You can design your cup using our online configurator — upload your logo, preview it in real time, and order directly. No quote requests or back-and-forth needed."
+    },
+    {
+      "question": "Are your eco-friendly cups actually compostable?",
+      "answer": "Our Vegware range is EN 13432 certified, which is the European standard for industrial compostability. That means they'll fully break down in a commercial composting facility within 12 weeks. They're made from plant-based materials — no petroleum plastics. We also carry recyclable PE-free cups for areas without commercial composting."
+    },
+    {
+      "question": "Do you offer trade pricing for coffee shops ordering regularly?",
+      "answer": "Absolutely. Most of our products include tiered pricing — the more you buy, the less you pay per unit. Many coffee shops set up regular monthly orders to lock in the best rates. We also offer a reorder scheduling feature so your packaging arrives automatically without you having to remember to place an order each time."
+    }
+  ],
+  "social_proof": {
+    "relevant_clients": ["La Gelatiera", "Hawksmoor", "Mandarin Oriental"],
+    "testimonial_angle": "Leading London cafés and restaurants trust Afida for their daily packaging needs."
+  }
+}

--- a/lib/tasks/pseo.rake
+++ b/lib/tasks/pseo.rake
@@ -1,0 +1,264 @@
+namespace :pseo do
+  desc "Generate business type pages from niche taxonomy using Claude API"
+  task generate_business_pages: :environment do
+    require "net/http"
+    require "json"
+    require "uri"
+
+    niches_dir = Rails.root.join("lib/data/pseo/niches")
+    output_dir = Rails.root.join("lib/data/pseo/pages/for")
+    FileUtils.mkdir_p(output_dir)
+
+    api_key = ENV.fetch("ANTHROPIC_API_KEY") do
+      Rails.application.credentials.dig(:anthropic, :api_key)
+    end
+
+    unless api_key.present?
+      puts "ERROR: ANTHROPIC_API_KEY not set. Set via environment variable or Rails credentials."
+      exit 1
+    end
+
+    niche_files = Dir.glob(niches_dir.join("*.json")).sort
+    if niche_files.empty?
+      puts "ERROR: No niche files found in #{niches_dir}"
+      exit 1
+    end
+
+    # Allow filtering to specific slugs via SLUGS env var
+    if ENV["SLUGS"].present?
+      target_slugs = ENV["SLUGS"].split(",").map(&:strip)
+      niche_files = niche_files.select { |f| target_slugs.include?(File.basename(f, ".json")) }
+    end
+
+    total = niche_files.size
+    successes = 0
+    failures = []
+
+    niche_files.each_with_index do |niche_file, index|
+      slug = File.basename(niche_file, ".json")
+      output_path = output_dir.join("#{slug}.json")
+
+      # Skip if already generated (use FORCE=1 to regenerate)
+      if output_path.exist? && ENV["FORCE"] != "1"
+        puts "[#{index + 1}/#{total}] SKIP #{slug} (already exists, use FORCE=1 to regenerate)"
+        successes += 1
+        next
+      end
+
+      puts "[#{index + 1}/#{total}] Generating #{slug}..."
+
+      niche_context = JSON.parse(File.read(niche_file))
+      retries = 0
+      max_retries = 2
+
+      begin
+        page_data = generate_page(api_key, niche_context)
+
+        # Validate the generated page
+        validator = PseoPageValidatorService.new(page_data)
+        result = validator.validate
+
+        unless result[:valid]
+          raise "Validation failed: #{result[:errors].join(', ')}"
+        end
+
+        File.write(output_path, JSON.pretty_generate(page_data))
+        puts "  ✓ Generated and validated #{slug}"
+        successes += 1
+
+      rescue => e
+        retries += 1
+        if retries <= max_retries
+          puts "  ✗ Error (attempt #{retries}/#{max_retries + 1}): #{e.message}"
+          puts "  Retrying..."
+          sleep(2 * retries)
+          retry
+        else
+          puts "  ✗ FAILED after #{max_retries + 1} attempts: #{e.message}"
+          failures << { slug: slug, error: e.message }
+        end
+      end
+
+      # Rate limiting: pause between API calls
+      sleep(1) if index < total - 1
+    end
+
+    puts "\n#{'=' * 60}"
+    puts "Generation complete: #{successes}/#{total} succeeded"
+    if failures.any?
+      puts "\nFailed pages:"
+      failures.each { |f| puts "  - #{f[:slug]}: #{f[:error]}" }
+    end
+  end
+
+  desc "Validate all generated PSEO pages against schema"
+  task validate: :environment do
+    pages_dir = Rails.root.join("lib/data/pseo/pages/for")
+
+    unless pages_dir.exist?
+      puts "No pages directory found at #{pages_dir}"
+      exit 1
+    end
+
+    page_files = Dir.glob(pages_dir.join("*.json")).sort
+    if page_files.empty?
+      puts "No page files found in #{pages_dir}"
+      exit 1
+    end
+
+    total = page_files.size
+    valid_count = 0
+    invalid_pages = []
+
+    page_files.each do |file|
+      slug = File.basename(file, ".json")
+      data = JSON.parse(File.read(file), symbolize_names: true)
+
+      validator = PseoPageValidatorService.new(data)
+      result = validator.validate
+
+      if result[:valid]
+        puts "  ✓ #{slug}"
+        valid_count += 1
+      else
+        puts "  ✗ #{slug}"
+        result[:errors].each { |e| puts "    - #{e}" }
+        invalid_pages << { slug: slug, errors: result[:errors] }
+      end
+    end
+
+    puts "\n#{'=' * 60}"
+    puts "Validation complete: #{valid_count}/#{total} valid"
+    if invalid_pages.any?
+      puts "\n#{invalid_pages.size} invalid page(s) need attention."
+      exit 1
+    end
+  end
+
+  desc "List all available niche slugs"
+  task list_niches: :environment do
+    niches_dir = Rails.root.join("lib/data/pseo/niches")
+    pages_dir = Rails.root.join("lib/data/pseo/pages/for")
+
+    niche_files = Dir.glob(niches_dir.join("*.json")).sort
+    puts "Available niches (#{niche_files.size} total):\n\n"
+
+    niche_files.each do |file|
+      slug = File.basename(file, ".json")
+      generated = pages_dir.join("#{slug}.json").exist?
+      status = generated ? "✓" : "·"
+      puts "  #{status} #{slug}"
+    end
+
+    generated_count = Dir.glob(pages_dir.join("*.json")).size
+    puts "\n#{generated_count}/#{niche_files.size} pages generated"
+  end
+end
+
+def generate_page(api_key, niche_context)
+  uri = URI("https://api.anthropic.com/v1/messages")
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  http.read_timeout = 120
+
+  system_prompt = <<~PROMPT
+    You are a packaging industry expert writing genuinely useful content for the Afida website (afida.com), a UK eco-friendly packaging supplier.
+
+    You are generating a structured page for the business type: #{niche_context["name"]}.
+
+    Context about this business type:
+    - Target audience: #{niche_context["audience"]}
+    - Key pain points: #{niche_context["pain_points"].join("; ")}
+    - Top product categories: #{niche_context["top_products"].join(", ")}
+    - Compliance concerns: #{niche_context["compliance_concerns"].join("; ")}
+    - Order frequency: #{niche_context["order_frequency"]}
+    - Average order size: #{niche_context["avg_order_size"]}
+    - Sustainability pressure: #{niche_context["sustainability_pressure"]}
+    - Branding interest: #{niche_context["branding_interest"]}
+
+    Afida context:
+    - UK eco-friendly packaging for food businesses
+    - USPs: Free delivery over £100, competitive wholesale pricing, eco/Vegware range, custom branding
+    - Notable clients: The Ritz, Marriott, Hawksmoor, La Gelatiera, Vincenzo's Pizzeria
+    - Categories: Cups & Drinks, Hot Food, Cold Food & Salads, Tableware, Bags & Wraps, Supplies & Essentials, Vegware, Branded
+
+    STRICT CONSTRAINTS:
+    - Exactly 4-6 packaging_needs entries (choose based on what's relevant to this business type)
+    - Exactly 5 faqs entries
+    - hero.intro: EXACTLY 150-200 words (count carefully)
+    - Each FAQ answer: EXACTLY 60-100 words (count carefully)
+    - All content must be specific to #{niche_context["name"]} — no generic packaging copy
+    - Write in a helpful, expert tone — this should be a useful guide, not an ad
+    - Use UK English spelling
+    - recommended_products should be slugified product names that would exist in a packaging catalogue
+  PROMPT
+
+  user_prompt = <<~PROMPT
+    Generate a complete page data JSON for "#{niche_context["name"]}" following this exact schema. Return ONLY valid JSON, no markdown code fences, no explanation.
+
+    {
+      "meta": {
+        "slug": "#{niche_context["slug"]}",
+        "business_type": "#{niche_context["name"]}",
+        "seo_title": "Packaging Supplies for #{niche_context["name"]} | Afida",
+        "seo_description": "...",
+        "keywords": ["...", "...", "...", "...", "..."]
+      },
+      "hero": {
+        "headline": "...",
+        "subheadline": "...",
+        "intro": "... (EXACTLY 150-200 words)"
+      },
+      "packaging_needs": [
+        {
+          "category": "...",
+          "why_it_matters": "...",
+          "recommended_products": ["slug-1", "slug-2"],
+          "buying_tip": "..."
+        }
+      ],
+      "sustainability_section": {
+        "intro": "...",
+        "options": [
+          { "name": "...", "benefit": "..." }
+        ]
+      },
+      "faqs": [
+        { "question": "...", "answer": "... (EXACTLY 60-100 words)" }
+      ],
+      "social_proof": {
+        "relevant_clients": ["The Ritz", "Hawksmoor"],
+        "testimonial_angle": "..."
+      }
+    }
+  PROMPT
+
+  request = Net::HTTP::Post.new(uri)
+  request["Content-Type"] = "application/json"
+  request["x-api-key"] = api_key
+  request["anthropic-version"] = "2023-06-01"
+  request.body = {
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 4096,
+    system: system_prompt,
+    messages: [
+      { role: "user", content: user_prompt }
+    ]
+  }.to_json
+
+  response = http.request(request)
+
+  unless response.code.to_i == 200
+    raise "API error (#{response.code}): #{response.body}"
+  end
+
+  response_data = JSON.parse(response.body)
+  content = response_data.dig("content", 0, "text")
+
+  raise "Empty response from API" if content.blank?
+
+  # Strip markdown code fences if present
+  content = content.gsub(/\A```(?:json)?\s*\n?/, "").gsub(/\n?```\s*\z/, "")
+
+  JSON.parse(content, symbolize_names: true)
+end

--- a/test/controllers/pseo_controller_test.rb
+++ b/test/controllers/pseo_controller_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class PseoControllerTest < ActionDispatch::IntegrationTest
+  test "business_type page returns 200 for valid slug" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_response :success
+  end
+
+  test "business_type page returns 404 for unknown slug" do
+    assert_raises(ActionController::RoutingError) do
+      get pseo_business_type_path(business_type: "nonexistent-business")
+    end
+  end
+
+  test "business_type page sets correct SEO title" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "title", "Packaging Supplies for Coffee Shops | Afida"
+  end
+
+  test "business_type page sets meta description" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "meta[name='description'][content=?]",
+      /Wholesale packaging for coffee shops/
+  end
+
+  test "business_type page renders H1 headline" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "h1", /Packaging Built for Coffee Shops/
+  end
+
+  test "business_type page renders intro paragraph" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "p", /Running a coffee shop means/
+  end
+
+  test "business_type page renders packaging needs cards" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "[data-testid='packaging-needs'] [data-testid='packaging-card']", { count: 5 }
+  end
+
+  test "business_type page renders FAQ accordion" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select ".collapse", { minimum: 5 }
+  end
+
+  test "business_type page renders sustainability section" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "[data-testid='sustainability-section']"
+  end
+
+  test "business_type page has FAQPage structured data" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "script[type='application/ld+json']", minimum: 1
+    assert_includes response.body, "FAQPage"
+  end
+
+  test "business_type page has BreadcrumbList structured data" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_includes response.body, "BreadcrumbList"
+  end
+
+  test "business_type page has canonical URL" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "link[rel='canonical']"
+  end
+
+  test "business_type page renders CTA section" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "[data-testid='cta-section']"
+    assert_select "a", /Shop.*Packaging/
+  end
+
+  test "business_type page prevents path traversal" do
+    assert_raises(ActionController::RoutingError) do
+      get pseo_business_type_path(business_type: "../../../etc/passwd")
+    end
+  end
+
+  test "business_type page renders social proof section" do
+    get pseo_business_type_path(business_type: "coffee-shops")
+
+    assert_select "[data-testid='social-proof']"
+  end
+end

--- a/test/helpers/application_helper_find_client_logo_test.rb
+++ b/test/helpers/application_helper_find_client_logo_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ApplicationHelperFindClientLogoTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "finds hawksmoor logo by exact name" do
+    assert_equal "hawksmoor.webp", find_client_logo("Hawksmoor")
+  end
+
+  test "finds la gelatiera logo by name" do
+    assert_equal "la-gelateria.webp", find_client_logo("La Gelatiera")
+  end
+
+  test "finds marriott logo by name" do
+    assert_equal "marriott.svg", find_client_logo("Marriott")
+  end
+
+  test "finds mandarin oriental logo" do
+    assert_equal "mandarin-oriental.svg", find_client_logo("Mandarin Oriental")
+  end
+
+  test "returns nil for unknown client" do
+    assert_nil find_client_logo("Unknown Client Name")
+  end
+
+  test "is case insensitive" do
+    assert_equal "hawksmoor.webp", find_client_logo("hawksmoor")
+  end
+end

--- a/test/services/pseo_page_validator_service_test.rb
+++ b/test/services/pseo_page_validator_service_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class PseoPageValidatorServiceTest < ActiveSupport::TestCase
+  def valid_page_data
+    JSON.parse(
+      Rails.root.join("lib/data/pseo/pages/for/coffee-shops.json").read,
+      symbolize_names: true
+    )
+  end
+
+  test "validates a well-formed page as valid" do
+    result = PseoPageValidatorService.new(valid_page_data).validate
+
+    assert result[:valid], "Expected valid page data to pass validation, errors: #{result[:errors]}"
+    assert_empty result[:errors]
+  end
+
+  test "requires meta section" do
+    data = valid_page_data
+    data.delete(:meta)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("meta") }
+  end
+
+  test "requires hero section" do
+    data = valid_page_data
+    data.delete(:hero)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("hero") }
+  end
+
+  test "requires 4-6 packaging_needs entries" do
+    data = valid_page_data
+    data[:packaging_needs] = data[:packaging_needs].first(3)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("packaging_needs") }
+  end
+
+  test "rejects more than 6 packaging_needs entries" do
+    data = valid_page_data
+    data[:packaging_needs] = data[:packaging_needs] * 2
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("packaging_needs") }
+  end
+
+  test "requires exactly 5 faqs" do
+    data = valid_page_data
+    data[:faqs] = data[:faqs].first(3)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("faqs") }
+  end
+
+  test "validates intro word count is 150-200 words" do
+    data = valid_page_data
+    data[:hero][:intro] = "Too short."
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("intro") }
+  end
+
+  test "validates FAQ answer word count is 60-100 words" do
+    data = valid_page_data
+    data[:faqs][0][:answer] = "Too short answer."
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("answer") }
+  end
+
+  test "requires sustainability_section" do
+    data = valid_page_data
+    data.delete(:sustainability_section)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("sustainability_section") }
+  end
+
+  test "requires social_proof section" do
+    data = valid_page_data
+    data.delete(:social_proof)
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("social_proof") }
+  end
+
+  test "requires meta slug" do
+    data = valid_page_data
+    data[:meta][:slug] = ""
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("slug") }
+  end
+
+  test "requires meta seo_title" do
+    data = valid_page_data
+    data[:meta][:seo_title] = ""
+
+    result = PseoPageValidatorService.new(data).validate
+
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("seo_title") }
+  end
+end

--- a/test/services/sitemap_generator_service_test.rb
+++ b/test/services/sitemap_generator_service_test.rb
@@ -153,4 +153,31 @@ class SitemapGeneratorServiceTest < ActiveSupport::TestCase
              "Sample pack #{pack.slug} should NOT be in /collections/ URLs"
     end
   end
+
+  test "includes PSEO business type pages" do
+    service = SitemapGeneratorService.new
+    xml = service.generate
+
+    doc = Nokogiri::XML(xml)
+    urls = doc.xpath("//xmlns:url/xmlns:loc").map(&:text)
+
+    # The coffee-shops page exists as seed data
+    assert urls.any? { |url| url.include?("/for/coffee-shops") },
+           "Expected sitemap to include /for/coffee-shops PSEO page"
+  end
+
+  test "PSEO pages have correct priority and changefreq" do
+    service = SitemapGeneratorService.new
+    xml = service.generate
+
+    doc = Nokogiri::XML(xml)
+    pseo_urls = doc.xpath("//xmlns:url").select do |url_node|
+      url_node.at_xpath("xmlns:loc").text.include?("/for/")
+    end
+
+    pseo_urls.each do |url_node|
+      assert_equal "0.8", url_node.at_xpath("xmlns:priority").text
+      assert_equal "monthly", url_node.at_xpath("xmlns:changefreq").text
+    end
+  end
 end


### PR DESCRIPTION
Build a complete pSEO infrastructure that generates structured, niche-specific
packaging guide pages at scale. Architecture separates content (JSON) from
presentation (ERB) so pages can be redesigned without regenerating content.

- PseoController with slug validation and path traversal protection
- ERB template with dark hero, packaging needs grid, sustainability section,
  FAQ accordion, social proof, and CTA — matching Afida's design system
- PseoPageValidatorService enforcing strict schema constraints (4-6 packaging
  needs, 5 FAQs, word count ranges for intro and answers)
- 60 niche context JSON files with UK-specific pain points, compliance
  concerns, and product recommendations
- Seed page data for coffee-shops as pilot
- Rake tasks for Claude API generation (pseo:generate_business_pages) and
  validation (pseo:validate)
- Sitemap integration with priority 0.8 and monthly changefreq
- Full test coverage: controller, validator service, sitemap, helper tests

https://claude.ai/code/session_018dwkgahCbPNPQNxVS9FY59