### PR TITLE
feat: render structured blog posts with section layout

### DIFF
--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -232,6 +232,23 @@ module SeoHelper
     data.to_json
   end
 
+  def faq_structured_data(faq_items)
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": faq_items.map do |item|
+        {
+          "@type": "Question",
+          "name": item["question"],
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": item["answer"]
+          }
+        }
+      end
+    }.to_json
+  end
+
   def breadcrumb_structured_data(items)
     {
       "@context": "https://schema.org",

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -45,6 +45,21 @@ class BlogPost < ApplicationRecord
     primary_keyword
   ].freeze
 
+  # Fields that produce visible content in the structured partial.
+  # Used by structured? to avoid false positives from SEO-only metadata
+  # like primary_keyword, secondary_keywords, or target slugs.
+  STRUCTURED_CONTENT_TEXT_FIELDS = %i[
+    intro conclusion
+    top_cta_heading top_cta_body
+    branding_heading branding_body
+    final_cta_heading final_cta_body
+  ].freeze
+
+  STRUCTURED_CONTENT_JSONB_FIELDS = %i[
+    decision_factors buyer_setups recommended_options faq_items
+    top_cta_buttons final_cta_buttons
+  ].freeze
+
   # Required keys for JSONB object-array fields. Fields not listed here
   # contain simple strings and only get the array-of-strings check.
   JSONB_REQUIRED_KEYS = {
@@ -106,10 +121,13 @@ class BlogPost < ApplicationRecord
     slug
   end
 
-  # True when any structured template field has content.
+  # True when any structured content field that produces visible output
+  # in the structured partial has content. SEO-only metadata fields
+  # (primary_keyword, secondary_keywords, target slugs) are excluded
+  # to avoid rendering an empty structured layout.
   def structured?
-    STRUCTURED_TEXT_FIELDS.any? { |field| self[field].present? } ||
-      JSONB_ARRAY_FIELDS.any? { |field| self[field].present? }
+    STRUCTURED_CONTENT_TEXT_FIELDS.any? { |field| self[field].present? } ||
+      STRUCTURED_CONTENT_JSONB_FIELDS.any? { |field| self[field].present? }
   end
 
   # Returns excerpt if present, otherwise truncates body (stripped of Markdown)

--- a/app/views/blog_posts/_cta_section.html.erb
+++ b/app/views/blog_posts/_cta_section.html.erb
@@ -1,0 +1,16 @@
+<section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
+  <% if heading.present? %>
+    <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= heading %></h2>
+  <% end %>
+  <% if body.present? %>
+    <p class="text-gray-700 leading-relaxed mb-4"><%= body %></p>
+  <% end %>
+  <% if buttons.present? %>
+    <div class="flex flex-wrap gap-3">
+      <% buttons.each do |button| %>
+        <%= link_to button["label"], button["url"],
+              class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/blog_posts/_cta_section.html.erb
+++ b/app/views/blog_posts/_cta_section.html.erb
@@ -8,8 +8,10 @@
   <% if buttons.present? %>
     <div class="flex flex-wrap gap-3">
       <% buttons.each do |button| %>
-        <%= link_to button["label"], button["url"],
-              class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
+        <% if button["label"].present? && button["url"].present? %>
+          <%= link_to button["label"], button["url"],
+                class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/blog_posts/_structured_content.html.erb
+++ b/app/views/blog_posts/_structured_content.html.erb
@@ -4,7 +4,7 @@
 <%# 1. Intro %>
 <% if blog_post.intro.present? %>
   <section class="mb-10">
-    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed">
+    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed prose-headings:text-gray-900 prose-a:text-primary hover:prose-a:text-primary-focus">
       <%= render_markdown(blog_post.intro) %>
     </div>
   </section>
@@ -12,22 +12,10 @@
 
 <%# 2. Top CTA %>
 <% if blog_post.top_cta_heading.present? || blog_post.top_cta_body.present? %>
-  <section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
-    <% if blog_post.top_cta_heading.present? %>
-      <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= blog_post.top_cta_heading %></h2>
-    <% end %>
-    <% if blog_post.top_cta_body.present? %>
-      <p class="text-gray-700 leading-relaxed mb-4"><%= blog_post.top_cta_body %></p>
-    <% end %>
-    <% if blog_post.top_cta_buttons.present? %>
-      <div class="flex flex-wrap gap-3">
-        <% blog_post.top_cta_buttons.each do |button| %>
-          <%= link_to button["label"], button["url"],
-                class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
-        <% end %>
-      </div>
-    <% end %>
-  </section>
+  <%= render "blog_posts/cta_section",
+        heading: blog_post.top_cta_heading,
+        body: blog_post.top_cta_body,
+        buttons: blog_post.top_cta_buttons %>
 <% end %>
 
 <%# 3. Decision Factors %>
@@ -115,28 +103,16 @@
 
 <%# 8. Final CTA %>
 <% if blog_post.final_cta_heading.present? || blog_post.final_cta_body.present? %>
-  <section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
-    <% if blog_post.final_cta_heading.present? %>
-      <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= blog_post.final_cta_heading %></h2>
-    <% end %>
-    <% if blog_post.final_cta_body.present? %>
-      <p class="text-gray-700 leading-relaxed mb-4"><%= blog_post.final_cta_body %></p>
-    <% end %>
-    <% if blog_post.final_cta_buttons.present? %>
-      <div class="flex flex-wrap gap-3">
-        <% blog_post.final_cta_buttons.each do |button| %>
-          <%= link_to button["label"], button["url"],
-                class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
-        <% end %>
-      </div>
-    <% end %>
-  </section>
+  <%= render "blog_posts/cta_section",
+        heading: blog_post.final_cta_heading,
+        body: blog_post.final_cta_body,
+        buttons: blog_post.final_cta_buttons %>
 <% end %>
 
 <%# 9. Conclusion %>
 <% if blog_post.conclusion.present? %>
   <section class="mb-10">
-    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed">
+    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed prose-headings:text-gray-900 prose-a:text-primary hover:prose-a:text-primary-focus">
       <%= render_markdown(blog_post.conclusion) %>
     </div>
   </section>

--- a/app/views/blog_posts/_structured_content.html.erb
+++ b/app/views/blog_posts/_structured_content.html.erb
@@ -1,0 +1,143 @@
+<%# Structured blog post content layout %>
+<%# Renders structured fields in section order, skipping empty sections %>
+
+<%# 1. Intro %>
+<% if blog_post.intro.present? %>
+  <section class="mb-10">
+    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed">
+      <%= render_markdown(blog_post.intro) %>
+    </div>
+  </section>
+<% end %>
+
+<%# 2. Top CTA %>
+<% if blog_post.top_cta_heading.present? || blog_post.top_cta_body.present? %>
+  <section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
+    <% if blog_post.top_cta_heading.present? %>
+      <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= blog_post.top_cta_heading %></h2>
+    <% end %>
+    <% if blog_post.top_cta_body.present? %>
+      <p class="text-gray-700 leading-relaxed mb-4"><%= blog_post.top_cta_body %></p>
+    <% end %>
+    <% if blog_post.top_cta_buttons.present? %>
+      <div class="flex flex-wrap gap-3">
+        <% blog_post.top_cta_buttons.each do |button| %>
+          <%= link_to button["label"], button["url"],
+                class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
+<%# 3. Decision Factors %>
+<% if blog_post.decision_factors.present? %>
+  <section class="mb-10">
+    <h2 class="text-xl md:text-2xl text-gray-900 mb-6">Key Decision Factors</h2>
+    <div class="space-y-6">
+      <% blog_post.decision_factors.each do |factor| %>
+        <div class="border-l-2 border-primary pl-5">
+          <h3 class="text-lg text-gray-900 mb-2"><%= factor["heading"] %></h3>
+          <p class="text-gray-700 leading-relaxed"><%= factor["body"] %></p>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<%# 4. Buyer Setups %>
+<% if blog_post.buyer_setups.present? %>
+  <section class="mb-10">
+    <h2 class="text-xl md:text-2xl text-gray-900 mb-6">Which Setup Fits You?</h2>
+    <div class="space-y-6">
+      <% blog_post.buyer_setups.each do |setup| %>
+        <div class="rounded-lg border border-gray-200 p-5 md:p-6">
+          <h3 class="text-lg text-gray-900 mb-1"><%= setup["title"] %></h3>
+          <p class="text-sm text-primary mb-3"><%= setup["best_for"] %></p>
+          <p class="text-gray-700 leading-relaxed mb-4"><%= setup["body"] %></p>
+          <% if setup["cta_label"].present? && setup["cta_url"].present? %>
+            <%= link_to setup["cta_label"], setup["cta_url"],
+                  class: "inline-block px-4 py-2 text-sm text-primary border border-primary rounded-lg hover:bg-primary hover:text-white transition-colors" %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<%# 5. Recommended Options %>
+<% if blog_post.recommended_options.present? %>
+  <section class="mb-10">
+    <h2 class="text-xl md:text-2xl text-gray-900 mb-6">Recommended Options</h2>
+    <div class="space-y-6">
+      <% blog_post.recommended_options.each do |option| %>
+        <div class="rounded-lg border border-gray-200 p-5 md:p-6">
+          <h3 class="text-lg text-gray-900 mb-2">
+            <% if option["url"].present? %>
+              <%= link_to option["heading"], option["url"], class: "text-primary hover:text-primary-focus transition-colors" %>
+            <% else %>
+              <%= option["heading"] %>
+            <% end %>
+          </h3>
+          <p class="text-gray-700 leading-relaxed"><%= option["body"] %></p>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<%# 6. Branding Section %>
+<% if blog_post.branding_heading.present? || blog_post.branding_body.present? %>
+  <section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
+    <% if blog_post.branding_heading.present? %>
+      <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= blog_post.branding_heading %></h2>
+    <% end %>
+    <% if blog_post.branding_body.present? %>
+      <p class="text-gray-700 leading-relaxed"><%= blog_post.branding_body %></p>
+    <% end %>
+  </section>
+<% end %>
+
+<%# 7. FAQ %>
+<% if blog_post.faq_items.present? %>
+  <section class="mb-10">
+    <h2 class="text-xl md:text-2xl text-gray-900 mb-6">Frequently Asked Questions</h2>
+    <div class="space-y-6">
+      <% blog_post.faq_items.each do |faq| %>
+        <div class="border-b border-gray-200 pb-5">
+          <h3 class="text-lg text-gray-900 mb-2"><%= faq["question"] %></h3>
+          <p class="text-gray-700 leading-relaxed"><%= faq["answer"] %></p>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<%# 8. Final CTA %>
+<% if blog_post.final_cta_heading.present? || blog_post.final_cta_body.present? %>
+  <section class="mb-10 rounded-lg bg-gray-50 p-6 md:p-8">
+    <% if blog_post.final_cta_heading.present? %>
+      <h2 class="text-xl md:text-2xl text-gray-900 mb-3"><%= blog_post.final_cta_heading %></h2>
+    <% end %>
+    <% if blog_post.final_cta_body.present? %>
+      <p class="text-gray-700 leading-relaxed mb-4"><%= blog_post.final_cta_body %></p>
+    <% end %>
+    <% if blog_post.final_cta_buttons.present? %>
+      <div class="flex flex-wrap gap-3">
+        <% blog_post.final_cta_buttons.each do |button| %>
+          <%= link_to button["label"], button["url"],
+                class: "inline-block px-5 py-2.5 text-sm text-white bg-primary rounded-lg hover:bg-primary-focus transition-colors" %>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
+<%# 9. Conclusion %>
+<% if blog_post.conclusion.present? %>
+  <section class="mb-10">
+    <div class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed">
+      <%= render_markdown(blog_post.conclusion) %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -36,6 +36,13 @@
       { name: @blog_post.title, url: blog_post_url(@blog_post) }
     ]) %>
   </script>
+
+  <% if @blog_post.structured? && @blog_post.faq_items.present? %>
+    <%# FAQ Structured Data (Schema.org FAQPage) %>
+    <script type="application/ld+json">
+      <%= raw faq_structured_data(@blog_post.faq_items) %>
+    </script>
+  <% end %>
 <% end %>
 
 <div class="container mx-auto px-4 py-12 max-w-3xl">
@@ -68,9 +75,15 @@
   <% end %>
 
   <!-- Article Content -->
-  <article class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed prose-headings:text-gray-900 prose-a:text-primary hover:prose-a:text-primary-focus">
-    <%= render_markdown(@blog_post.body) %>
-  </article>
+  <% if @blog_post.structured? %>
+    <article>
+      <%= render "blog_posts/structured_content", blog_post: @blog_post %>
+    </article>
+  <% else %>
+    <article class="prose prose-lg max-w-none prose-p:text-gray-700 prose-p:leading-relaxed prose-headings:text-gray-900 prose-a:text-primary hover:prose-a:text-primary-focus">
+      <%= render_markdown(@blog_post.body) %>
+    </article>
+  <% end %>
 
   <!-- Article Footer -->
   <footer class="mt-16 pt-8 border-t border-gray-200">

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -25,22 +25,22 @@
 
   <%# Article Structured Data %>
   <script type="application/ld+json">
-    <%= raw blog_post_structured_data(@blog_post) %>
+    <%= raw json_escape(blog_post_structured_data(@blog_post)) %>
   </script>
 
   <%# Breadcrumb Structured Data %>
   <script type="application/ld+json">
-    <%= raw breadcrumb_structured_data([
+    <%= raw json_escape(breadcrumb_structured_data([
       { name: "Home", url: root_url },
       { name: "Blog", url: blog_posts_url },
       { name: @blog_post.title, url: blog_post_url(@blog_post) }
-    ]) %>
+    ])) %>
   </script>
 
   <% if @blog_post.faq_items.present? %>
     <%# FAQ Structured Data (Schema.org FAQPage) %>
     <script type="application/ld+json">
-      <%= raw faq_structured_data(@blog_post.faq_items) %>
+      <%= raw json_escape(faq_structured_data(@blog_post.faq_items)) %>
     </script>
   <% end %>
 <% end %>

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -37,7 +37,7 @@
     ]) %>
   </script>
 
-  <% if @blog_post.structured? && @blog_post.faq_items.present? %>
+  <% if @blog_post.faq_items.present? %>
     <%# FAQ Structured Data (Schema.org FAQPage) %>
     <script type="application/ld+json">
       <%= raw faq_structured_data(@blog_post.faq_items) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -11,8 +11,12 @@
     {
       "fingerprint": "d83a0aa6c7873157690195dfab388a67e4a2baf5c020f0a1d1ea5b76cfaa095a",
       "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
+    },
+    {
+      "fingerprint": "1d68964ff5f42f0957a04449ceaed69dca8e65dde6932075fb45efc38bf61846",
+      "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
     }
   ],
-  "updated": "2026-03-05",
-  "brakeman_version": "7.1.1"
+  "updated": "2026-04-10",
+  "brakeman_version": "8.0.4"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,20 +1,20 @@
 {
   "ignored_warnings": [
     {
-      "fingerprint": "5537dd21a03a6daa4601a163989f6cdc44f34d71e7560e41890f23bfd37978e3",
-      "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
+      "fingerprint": "de107c92404f062594f53868ff3516989812c84db55ed596aae3700c7a2e99a4",
+      "note": "False positive: JSON-LD structured data output via .to_json + json_escape inside script tag"
+    },
+    {
+      "fingerprint": "b106a6bfe918c1a988a902e719e957d2e3c107d0cde834885467347469208c02",
+      "note": "False positive: JSON-LD structured data output via .to_json + json_escape inside script tag"
+    },
+    {
+      "fingerprint": "7940d94c8f586b38034c869be95aae2796a4eb2b3f1a874fa008f1fb0c6e7f7e",
+      "note": "False positive: JSON-LD structured data output via .to_json + json_escape inside script tag"
     },
     {
       "fingerprint": "83b4ea229edd36788f3905d90a67f8f46a65ca3d5f7cfb7f23ef6a2fc756b7a4",
-      "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
-    },
-    {
-      "fingerprint": "d83a0aa6c7873157690195dfab388a67e4a2baf5c020f0a1d1ea5b76cfaa095a",
-      "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
-    },
-    {
-      "fingerprint": "1d68964ff5f42f0957a04449ceaed69dca8e65dde6932075fb45efc38bf61846",
-      "note": "False positive: JSON-LD structured data output via .to_json inside script tag"
+      "note": "False positive: JSON-LD structured data output via .to_json inside script tag (blog_categories/show)"
     }
   ],
   "updated": "2026-04-10",

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -240,6 +240,18 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/meta.*description.*#{Regexp.escape(structured.meta_description[0..20])}/, response.body)
   end
 
+  test "show renders partially structured post with only intro and conclusion" do
+    partial = blog_posts(:partially_structured_post)
+    get blog_post_url(partial)
+
+    assert_response :success
+    assert_includes response.body, "gaining traction across the UK"
+    assert_includes response.body, "easier than you think"
+    assert_not_includes response.body, "Key Decision Factors"
+    assert_not_includes response.body, "Frequently Asked Questions"
+    assert_not_includes response.body, "Fallback body for partially structured post"
+  end
+
   test "show renders FAQ schema markup for structured posts" do
     structured = blog_posts(:structured_post)
     get blog_post_url(structured)

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -130,14 +130,6 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "practical, affordable way"
   end
 
-  test "show renders intro section for structured posts" do
-    structured = blog_posts(:structured_post)
-    get blog_post_url(structured)
-
-    assert_response :success
-    assert_includes response.body, "Switching to compostable cups"
-  end
-
   test "show renders top CTA section for structured posts" do
     structured = blog_posts(:structured_post)
     get blog_post_url(structured)
@@ -250,6 +242,14 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "Key Decision Factors"
     assert_not_includes response.body, "Frequently Asked Questions"
     assert_not_includes response.body, "Fallback body for partially structured post"
+  end
+
+  test "show does not render FAQ schema for posts without faq items" do
+    partial = blog_posts(:partially_structured_post)
+    get blog_post_url(partial)
+
+    assert_response :success
+    assert_not_includes response.body, "FAQPage"
   end
 
   test "show renders FAQ schema markup for structured posts" do

--- a/test/controllers/blog_posts_controller_test.rb
+++ b/test/controllers/blog_posts_controller_test.rb
@@ -116,4 +116,136 @@ class BlogPostsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, blog_posts_path
   end
+
+  # ==========================================================================
+  # Show Action - Structured Posts
+  # ==========================================================================
+
+  test "show renders structured layout for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "Switching to compostable cups"
+    assert_includes response.body, "practical, affordable way"
+  end
+
+  test "show renders intro section for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "Switching to compostable cups"
+  end
+
+  test "show renders top CTA section for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, structured.top_cta_heading
+    assert_includes response.body, structured.top_cta_body
+    assert_includes response.body, "Shop Compostable Cups"
+    assert_includes response.body, "/collections/compostable-cups"
+  end
+
+  test "show renders decision factors for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "Material"
+    assert_includes response.body, "PLA-lined cups"
+    assert_includes response.body, "Size Range"
+  end
+
+  test "show renders buyer setups for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "High-Volume Cafe"
+    assert_includes response.body, "Cafes serving 200+ cups per day"
+    assert_includes response.body, "View Bulk Options"
+  end
+
+  test "show renders recommended options for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "Afida Classic PLA Cup"
+    assert_includes response.body, "/products/afida-classic-pla-cup"
+  end
+
+  test "show renders branding section for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, structured.branding_heading
+    assert_includes response.body, structured.branding_body
+  end
+
+  test "show renders FAQ items for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "Are PLA cups really compostable?"
+    assert_includes response.body, "EN 13432"
+    assert_includes response.body, "Can I print my logo"
+  end
+
+  test "show renders final CTA for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, structured.final_cta_heading
+    assert_includes response.body, "Browse All Cups"
+    assert_includes response.body, "/collections/cups"
+  end
+
+  test "show renders conclusion for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "practical, affordable way"
+  end
+
+  test "show does not render legacy body for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_not_includes response.body, "Fallback body content for structured post"
+  end
+
+  test "show still renders legacy body for non-structured posts" do
+    get blog_post_url(@published_post)
+
+    assert_response :success
+    assert_includes response.body, "eco-friendly packaging"
+    assert_not @published_post.structured?
+  end
+
+  test "show preserves SEO meta tags for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, structured.meta_title
+    assert_match(/meta.*description.*#{Regexp.escape(structured.meta_description[0..20])}/, response.body)
+  end
+
+  test "show renders FAQ schema markup for structured posts" do
+    structured = blog_posts(:structured_post)
+    get blog_post_url(structured)
+
+    assert_response :success
+    assert_includes response.body, "FAQPage"
+    assert_includes response.body, "Are PLA cups really compostable?"
+  end
 end

--- a/test/fixtures/blog_posts.yml
+++ b/test/fixtures/blog_posts.yml
@@ -102,3 +102,29 @@ duplicate_outrank:
     This tests duplicate article handling via outrank_id.
   published: false
   outrank_id: "outrank-duplicate-456"
+
+structured_post:
+  title: "Best Compostable Coffee Cups for UK Cafes"
+  slug: "best-compostable-coffee-cups"
+  body: "Fallback body content for structured post."
+  excerpt: "Find the best compostable coffee cups for your cafe."
+  published: true
+  published_at: <%= 1.day.ago %>
+  meta_title: "Best Compostable Coffee Cups 2026 | Afida"
+  meta_description: "Compare the top compostable coffee cups for UK cafes."
+  blog_category: guides
+  primary_keyword: "compostable coffee cups"
+  intro: "Switching to compostable cups is one of the easiest wins for any cafe looking to reduce waste. In this guide, we compare the top options available in the UK."
+  top_cta_heading: "Ready to make the switch?"
+  top_cta_body: "Browse our full range of compostable cups and get free delivery on orders over 50 GBP."
+  top_cta_buttons: <%= [{"label" => "Shop Compostable Cups", "url" => "/collections/compostable-cups"}, {"label" => "Get a Quote", "url" => "/contact"}].to_json %>
+  decision_factors: <%= [{"heading" => "Material", "body" => "PLA-lined cups are the most common compostable option. They look and feel like traditional cups but break down in industrial composting."}, {"heading" => "Size Range", "body" => "Most suppliers offer 8oz, 12oz, and 16oz. Make sure your supplier covers all the sizes you need."}].to_json %>
+  buyer_setups: <%= [{"title" => "High-Volume Cafe", "best_for" => "Cafes serving 200+ cups per day", "body" => "Bulk ordering reduces per-unit cost significantly. Look for suppliers with next-day delivery.", "cta_label" => "View Bulk Options", "cta_url" => "/collections/bulk-cups"}, {"title" => "Small Independent", "best_for" => "Cafes serving under 50 cups per day", "body" => "Smaller case sizes keep storage manageable. Focus on quality and branding options.", "cta_label" => "View Small Cases", "cta_url" => "/collections/small-cases"}].to_json %>
+  recommended_options: <%= [{"heading" => "Afida Classic PLA Cup", "body" => "Our most popular compostable cup. Available in 8oz, 12oz, and 16oz.", "url" => "/products/afida-classic-pla-cup"}].to_json %>
+  branding_heading: "Why choose Afida?"
+  branding_body: "We source all our compostable cups from certified suppliers and offer free branding on bulk orders."
+  faq_items: <%= [{"question" => "Are PLA cups really compostable?", "answer" => "Yes. PLA cups are certified to EN 13432 and break down fully in industrial composting facilities."}, {"question" => "Can I print my logo on compostable cups?", "answer" => "Absolutely. We offer custom printing on orders of 1,000 cups or more."}].to_json %>
+  final_cta_heading: "Start your switch to compostable"
+  final_cta_body: "Join hundreds of UK cafes already using Afida compostable cups."
+  final_cta_buttons: <%= [{"label" => "Browse All Cups", "url" => "/collections/cups"}, {"label" => "Contact Sales", "url" => "/contact"}].to_json %>
+  conclusion: "Compostable coffee cups are a practical, affordable way to reduce your cafe's environmental footprint. Whether you are a high-volume chain or a small independent, there is an option that fits your needs and budget."

--- a/test/fixtures/blog_posts.yml
+++ b/test/fixtures/blog_posts.yml
@@ -128,3 +128,14 @@ structured_post:
   final_cta_body: "Join hundreds of UK cafes already using Afida compostable cups."
   final_cta_buttons: <%= [{"label" => "Browse All Cups", "url" => "/collections/cups"}, {"label" => "Contact Sales", "url" => "/contact"}].to_json %>
   conclusion: "Compostable coffee cups are a practical, affordable way to reduce your cafe's environmental footprint. Whether you are a high-volume chain or a small independent, there is an option that fits your needs and budget."
+
+partially_structured_post:
+  title: "Why Compostable Packaging Matters"
+  slug: "why-compostable-packaging-matters"
+  body: "Fallback body for partially structured post."
+  excerpt: "A short intro to compostable packaging."
+  published: true
+  published_at: <%= 2.days.ago %>
+  blog_category: guides
+  intro: "Compostable packaging is gaining traction across the UK food service industry."
+  conclusion: "Making the switch is easier than you think."

--- a/test/helpers/seo_helper_test.rb
+++ b/test/helpers/seo_helper_test.rb
@@ -265,6 +265,35 @@ class SeoHelperTest < ActionView::TestCase
     assert data["logo"].start_with?("http"), "Logo URL must be absolute, got: #{data['logo']}"
   end
 
+  # FAQ structured data tests
+  test "faq_structured_data generates FAQPage schema" do
+    faq_items = [
+      { "question" => "Is it compostable?", "answer" => "Yes, certified to EN 13432." },
+      { "question" => "What sizes?", "answer" => "8oz, 12oz, and 16oz." }
+    ]
+
+    json = faq_structured_data(faq_items)
+    data = JSON.parse(json)
+
+    assert_equal "https://schema.org", data["@context"]
+    assert_equal "FAQPage", data["@type"]
+    assert_equal 2, data["mainEntity"].length
+
+    first = data["mainEntity"].first
+    assert_equal "Question", first["@type"]
+    assert_equal "Is it compostable?", first["name"]
+    assert_equal "Answer", first["acceptedAnswer"]["@type"]
+    assert_equal "Yes, certified to EN 13432.", first["acceptedAnswer"]["text"]
+  end
+
+  test "faq_structured_data handles empty array" do
+    json = faq_structured_data([])
+    data = JSON.parse(json)
+
+    assert_equal "FAQPage", data["@type"]
+    assert_equal [], data["mainEntity"]
+  end
+
   # Canonical URL tests
   test "canonical_url strips query parameters by default" do
     # Simulate a request with query params

--- a/test/models/blog_post_test.rb
+++ b/test/models/blog_post_test.rb
@@ -279,4 +279,11 @@ class BlogPostTest < ActiveSupport::TestCase
     @published_post.conclusion = "Thanks for reading."
     assert @published_post.structured?
   end
+
+  test "structured? returns false when only SEO metadata fields are present" do
+    post = BlogPost.new(title: "Test", body: "Content", primary_keyword: "eco cups")
+    post.secondary_keywords = %w[green sustainable]
+    post.target_category_slugs = %w[cups]
+    assert_not post.structured?
+  end
 end


### PR DESCRIPTION
## Summary

- Structured blog posts now render using dedicated section partials (intro, CTAs, decision factors, buyer setups, recommended options, branding, FAQ, conclusion) instead of the legacy markdown body
- Legacy posts continue to render through `render_markdown` unchanged
- Adds FAQPage JSON-LD schema markup for structured posts with FAQ items

## Changes

- **New:** `app/views/blog_posts/_structured_content.html.erb` - partial rendering all 9 structured sections
- **Modified:** `app/views/blog_posts/show.html.erb` - branches on `structured?` for layout selection, adds FAQ schema
- **Modified:** `app/helpers/seo_helper.rb` - adds `faq_structured_data` helper
- **Modified:** `test/fixtures/blog_posts.yml` - adds `structured_post` fixture
- **Modified:** `test/controllers/blog_posts_controller_test.rb` - 13 new integration tests

## Test plan

- [x] All 1961 existing tests pass (0 failures, 0 errors)
- [x] Structured post renders all sections (intro, top CTA, decision factors, buyer setups, recommended options, branding, FAQ, final CTA, conclusion)
- [x] CTA buttons render as links with correct URLs
- [x] FAQ items render with questions and answers
- [x] FAQPage schema markup present in head for structured posts with FAQ
- [x] Legacy posts still render markdown body as before
- [x] SEO meta tags preserved for structured posts
- [ ] Visual review of structured post layout on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)