### PR TITLE
Add buying guide to /collections/restaurants

### DIFF
--- a/db/migrate/20260511120000_populate_restaurants_collection_buying_guide.rb
+++ b/db/migrate/20260511120000_populate_restaurants_collection_buying_guide.rb
@@ -1,0 +1,10 @@
+class PopulateRestaurantsCollectionBuyingGuide < ActiveRecord::Migration[8.1]
+  def up
+    buying_guide = File.read(Rails.root.join("lib/data/collections/buying-guides/restaurants.md"))
+    Collection.find_by(slug: "restaurants")&.update!(buying_guide: buying_guide)
+  end
+
+  def down
+    Collection.find_by(slug: "restaurants")&.update!(buying_guide: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_11_004508) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/lib/data/collections/buying-guides/restaurants.md
+++ b/lib/data/collections/buying-guides/restaurants.md
@@ -1,0 +1,65 @@
+Running a restaurant in 2026 means stocking packaging for two very different operations under one roof: the dine-in service that defines your brand, and the delivery channel that increasingly pays the bills. Restaurant packaging has to hold up to gravy, oil, and forty-minute moped journeys, fit into Deliveroo and Uber Eats bag pockets, and still look acceptable when a customer opens the bag at home. This guide explains what to buy across containers, lids, napkins, cutlery, and bags, where the trade-offs sit, and how to keep the unit economics from eating your margin.
+
+## Key Factors to Consider
+
+### Food Containers: Matching Container to Dish
+
+The single most expensive packaging mistake is using the wrong container for the dish. A curry in a flat-bottomed cardboard box leaks before it leaves the kitchen. A burger in a tall soup pot steams itself into a soggy mess. Match container to food first, brand and finish second.
+
+For wet, saucy dishes (curries, stews, rice with sauce), use leak-resistant food containers with a sealed-clip or screw-on lid. Round or rectangular polypropylene pots, kraft soup cups with paper or PLA lids, and bagasse bowls with snap-fit lids all work. For hot dry dishes (burgers, fried chicken, fish and chips), use ventilated burger boxes or open-top trays that let steam escape so the food does not condense and go limp. For cold dishes (salads, sandwiches, deli boxes), use clear-lid containers so customers see the food before they open it.
+
+Sizes matter for portion control as much as packaging cost. A 500ml container for a main, 250ml for a side, and 100ml portion pots for dips and dressings is the standard restaurant set. Standardising on a small number of sizes simplifies kitchen workflow and keeps your packaging spend predictable.
+
+### Lids: The Compatibility Trap
+
+Lid compatibility is where restaurants waste money. Buying cups and lids from different ranges or suppliers means you end up with stock that does not match: lids that almost-but-not-quite fit, lids that pop off when the bag is jostled, and SKUs that proliferate every time someone reorders the wrong size.
+
+Stick to one cup-and-lid system where you can. The 89mm rim diameter covers most hot cups and paper cold cups across brands. The 96mm rim covers PLA clear cold cups. A lid designed for the 89-Series will fit any 89-Series cup regardless of capacity, so a single lid SKU can cover your 8oz, 12oz, and 16oz cups. When ordering, check the rim diameter before checking the brand. Sip-through lids suit hot drinks and takeaway coffee; flat lids with a straw slot suit cold drinks and milkshakes; dome lids with a hole suit smoothies and whipped toppings.
+
+For food containers, the bagasse and PLA lid ranges use numbered size groups (Size 3, Size 4, Size 5). One lid size fits several base capacities within the same group. Map your dish portions to the smallest number of size groups you can.
+
+### Napkins: Ply, Size, and the Branding Question
+
+Napkins look like a commodity buy until you compare a thin one-ply against a heavyweight two-ply at the table. Ply is the number of paper layers laminated together: one-ply is the cheapest and works for cocktail use or wipe-down service, two-ply is the standard for dine-in restaurants, and three-ply gives a near-cloth feel for premium service.
+
+Size and fold matter for presentation. Cocktail napkins (about 24cm) suit drinks service, lunch napkins (33cm) suit fast-casual, and dinner napkins (40cm and up) suit table service. Quarter-fold and eighth-fold are the two common formats; quarter-fold sits flat under cutlery on the table, eighth-fold suits dispensers and takeaway bags.
+
+For delivery, branded napkins are an easy win. A logo-printed napkin in a Deliveroo bag costs marginally more than plain but reinforces brand recognition for the cost of one extra ink pass per pack. Plain unprinted napkins are fine for back-of-house and for restaurants that prioritise food cost over brand visibility.
+
+### Cutlery: Wood, PLA, or Conventional Plastic
+
+Since the 2023 UK ban on single-use plastic cutlery for businesses, the practical options are wood, paper, and PLA. Wood cutlery (birch or bamboo) is the most common and feels solid in the hand; PLA looks closest to conventional plastic but warps with very hot food; paper cutlery is the cheapest and works for cold dishes and quick service but is rarely robust enough for full meals.
+
+Loose cutlery costs less per piece but slows packing. Pre-assembled cutlery kits (knife, fork, napkin, salt and pepper sachets wrapped together) cost more per unit but cut your packing time in half during the dinner rush. For delivery operations doing more than 50 orders an evening, the labour saving from kits typically outweighs the unit-cost premium.
+
+### Bags: The Last Step Before the Customer
+
+The bag is the first thing a delivery customer sees, and it has to do real work: hold a hot main, a cold drink, and a bag of chips without splitting, sweating, or tipping over in a courier's moped pannier. Kraft paper bags with twisted or flat handles are the restaurant standard. Match bag size to your typical order: a single-meal order needs a small bag with handles, a family order needs a large bag, and a delivery for two often falls in between.
+
+For wet or oily food, choose greaseproof-lined bags or stack a greaseproof sheet inside a plain kraft bag. For premium service, kraft window bags let the customer glimpse the food before opening, which works well for bakery items and deli boxes. For cold delivery (salads, sushi, ice cream), insulated therma bags keep the chain intact for the 30 to 45 minutes a typical delivery takes.
+
+Sealing matters for Deliveroo and Uber Eats compliance. A round sticker over the bag handles, or a tamper-evident seal sticker across the bag opening, signals to the customer that no one has opened the bag between kitchen and door. This is increasingly a customer expectation, not an optional extra.
+
+### Cost and Volume Planning
+
+Restaurant packaging spend typically runs 2 to 4 percent of revenue for a dine-in restaurant and 4 to 7 percent for a delivery-led operation. The largest line items are food containers, cups and lids, and bags. Order in case quantities rather than packs once your volume is steady: a case of 250 containers usually costs 15 to 25 percent less per unit than a pack of 50, and most restaurant kitchens go through a case a week of their main container size.
+
+Build a reorder cycle around your dish-to-container mapping. Identify your three highest-volume containers, set par stock at three weeks of cover, and reorder when you hit one week. This keeps you out of stockouts during weekend rushes without tying up cash in slow-moving inventory.
+
+### Sustainability and Customer Expectations
+
+Compostable and recyclable packaging used to be a premium positioning choice; it is now a baseline expectation for most casual-dining and delivery customers. Bagasse, kraft, PLA-lined paper, and recycled-fibre containers cover almost any restaurant use case. EN 13432 certification is the standard to look for on compostable packaging: it means the product breaks down fully under commercial composting conditions.
+
+The caveat is that "compostable" only works if your local waste collection accepts it, and most UK council collections do not. Be honest with customers: certified compostable packaging is a credible position if you also explain what happens to it after they finish their meal. Vague "eco-friendly" claims without certification or disposal context invite scepticism.
+
+## Pro Tips
+
+- Order sample packs of any new container with a sauced dish before committing to a full case. Leak rates that look fine in the kitchen go up when the container is sealed, bagged, and ridden on a moped for 30 minutes.
+- Print run breakeven for branded napkins is usually 5,000 to 10,000 units. If you do over 500 orders a week with one napkin per order, custom-printed napkins pay back in well under a year.
+- For delivery-led operations, standardise on one bag size for 80 percent of orders and stock a larger size for family and group orders. Two bag SKUs cover almost every situation and keep packing fast.
+- Tamper-evident seal stickers add about 1p per order and reduce the number of "missing items" customer-service tickets significantly. Cheap insurance.
+- Cutlery kits earn back the unit-cost premium during a busy Friday or Saturday evening service when the kitchen pass cannot afford to slow down for packing.
+
+## Summary
+
+Restaurant packaging is a margin business: every container, lid, napkin, and bag has a cost-per-order that compounds across thousands of covers a week. The basics that matter are matching containers to dishes, standardising on a single cup-and-lid system, stocking the right ply and size of napkin for your service style, and choosing cutlery and bags that hold up to the realities of delivery rather than just looking the part in the kitchen. Get those right, control your case-pack economics with a tight reorder cycle, and the packaging stops being a cost centre and starts reinforcing the operation that earned the order in the first place.


### PR DESCRIPTION
## Summary

- Adds a 1,500-word buying guide to `/collections/restaurants`, populated via a one-shot data migration from `lib/data/collections/buying-guides/restaurants.md`.
- Targets page-2 queries: GSC shows the page at position 17.4 with 249 impressions and 0 clicks over the last 90 days. Top queries cluster around *restaurant packaging*, *restaurant paper products*, *restaurant takeaway containers*, *takeaway supplies*.
- Renders through the existing `shared/_buying_guide` partial and emits Article JSON-LD via `collection_buying_guide_structured_data` (same path the Vegware filter guides use).

## Why restaurants over takeaway

The original Tier 2 plan named `/collections/takeaway` as flagship. Fresh GSC data shows takeaway sitting at position 31.2, which is too deep for content alone to climb. `/collections/restaurants` has the largest non-Vegware impression base near page 1 (249 imp at pos 17.4), making it the highest-leverage next target.

## Content scope

Sections mirror the structure of the existing Vegware guide:
- Container-to-dish matching (wet, dry, cold)
- Cup/lid compatibility (89-Series vs 96-Series, Size 3/4/5 groups)
- Napkin ply, size, and branding economics
- Post-2023 cutlery options (wood, PLA, paper) and kit vs loose
- Delivery bag sizing and tamper-evident sealing
- Cost as % of revenue and reorder cycles
- EN 13432 sustainability and customer expectations
- Pro Tips + Summary

## Test plan

- [x] `bin/rails db:migrate` + rollback + re-migrate locally confirms idempotency
- [x] Full suite green (2,172 runs, 6,561 assertions, 0 failures)
- [x] Local render at `/collections/restaurants` (with seeded test row) shows `section.buying-guide`, all H2/H3 headings, and Article JSON-LD
- [x] Zero em dashes, zero markdown bold (`**`) — complies with project style rules
- [ ] After merge + deploy: production migration applies (collection exists per kamal check); spot-check the page renders