### PR TITLE
Extract checkout services

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -5,6 +5,8 @@ class CheckoutsController < ApplicationController
 
   def create
     cart = Current.cart
+    # Kept outside the begin block so the rescue path can inspect builder state
+    # after Stripe raises during session creation.
     builder = nil
 
     begin

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -8,124 +8,8 @@ class CheckoutsController < ApplicationController
 
   def create
     cart = Current.cart
-    # Eager load associations to prevent N+1 queries when building Stripe line items
-    cart_items = cart.cart_items.includes(CART_ITEM_INCLUDES)
-    line_items = cart_items.map do |item|
-      # For standard products with pack pricing: send packs as quantity
-      # For branded/configured products: send units as quantity
-      product = item.product
-
-      if item.sample?
-        # Sample items: free, quantity 1
-        quantity = 1
-        unit_amount = 0
-        product_name = "#{product.generated_title} (Sample)"
-      elsif item.configured?
-        # Unit-based pricing (branded products)
-        quantity = 1
-        unit_amount = (item.price.to_f * item.quantity * 100).round
-        units_formatted = ActiveSupport::NumberHelper.number_to_delimited(item.quantity)
-        product_name = "#{product.generated_title} - #{item.configuration['size']} (#{units_formatted} units)"
-      elsif product.pac_size.blank? || product.pac_size.zero?
-        # Unit-based pricing (products without packs)
-        quantity = item.quantity
-        unit_amount = (item.price.to_f * 100).round
-        product_name = product.generated_title
-      else
-        # Pack-based pricing (standard products)
-        packs_needed = item.quantity
-        quantity = 1
-        unit_amount = (item.price.to_f * packs_needed * 100).round
-        packs_label = packs_needed == 1 ? "pack" : "packs"
-        product_name = "#{product.generated_title} (#{packs_needed} #{packs_label})"
-      end
-
-      {
-        quantity: quantity,
-        price_data: {
-          currency: "gbp",
-          product_data: {
-            name: product_name
-          },
-          unit_amount: unit_amount,
-          tax_behavior: "exclusive"
-        },
-        tax_rates: [ tax_rate.id ]
-      }
-    end
 
     begin
-      # Determine shipping options based on order type and subtotal:
-      # - Samples-only orders: Fixed sample delivery rate
-      # - Orders >= £100 subtotal: Free shipping
-      # - Orders < £100 subtotal: Standard shipping (£5)
-      shipping_options = if cart.only_samples?
-        [ Shipping.sample_only_shipping_option ]
-      else
-        Shipping.shipping_options_for_subtotal(cart.subtotal_amount)
-      end
-
-      session_params = {
-        payment_method_types: [ "card" ],
-        line_items: line_items,
-        mode: "payment",
-        shipping_address_collection: {
-          allowed_countries: Shipping::ALLOWED_COUNTRIES
-        },
-        shipping_options: shipping_options,
-        success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
-        cancel_url: cancel_checkout_url,
-        metadata: {
-          cart_id: cart.id.to_s,
-          discount_code: session[:discount_code],
-          datafast_visitor_id: cookies[:datafast_visitor_id],
-          datafast_session_id: cookies[:datafast_session_id]
-        }
-      }
-
-      # Apply discount coupon if present in session, otherwise allow customer to enter a promotion code
-      if session[:discount_code].present?
-        # Programmatic discount (e.g. email signup) - validate and apply directly
-        begin
-          Stripe::Coupon.retrieve(session[:discount_code])
-          session_params[:discounts] = [ { coupon: session[:discount_code] } ]
-        rescue Stripe::InvalidRequestError => e
-          # Coupon doesn't exist or is invalid - log and continue without discount
-          Rails.logger.warn("Invalid discount coupon '#{session[:discount_code]}': #{e.message}")
-          session.delete(:discount_code)
-          flash[:alert] = "Your discount code could not be applied. Please continue with your order."
-          # Fall back to allowing customer-entered promotion codes
-          session_params[:allow_promotion_codes] = true
-        end
-      else
-        # No programmatic discount - let customers enter promotion codes on checkout page
-        session_params[:allow_promotion_codes] = true
-      end
-
-      if Current.user
-        session_params[:client_reference_id] = Current.user.id
-
-        # If user selected an address, sync it to Stripe Customer for prefill
-        if params[:address_id].present?
-          address = Current.user.addresses.find_by(id: params[:address_id])
-          if address
-            # Sync address to Stripe Customer (creates customer if needed)
-            Current.user.sync_stripe_customer!(address: address)
-            session[:selected_address_id] = params[:address_id]
-
-            # Use Stripe Customer for address prefill
-            session_params[:customer] = Current.user.stripe_customer_id
-          else
-            # Address not found - fall back to email only
-            session_params[:customer_email] = Current.user.email_address
-          end
-        else
-          # User chose "Enter a different address" or has no addresses
-          # Use customer_email so Stripe doesn't prefill from existing Customer
-          session_params[:customer_email] = Current.user.email_address
-        end
-      end
-
       # Emit checkout.started event for funnel tracking
       Rails.event.notify("checkout.started",
         cart_id: cart.id,
@@ -133,10 +17,28 @@ class CheckoutsController < ApplicationController
         subtotal: cart.subtotal_amount
       )
 
-      session = Stripe::Checkout::Session.create(session_params)
+      builder = Checkout::SessionBuilder.new(
+        cart: cart,
+        user: Current.user,
+        address_id: params[:address_id],
+        discount_code: session[:discount_code],
+        datafast_visitor_id: cookies[:datafast_visitor_id],
+        datafast_session_id: cookies[:datafast_session_id],
+        success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: cancel_checkout_url
+      )
+      result = builder.create
 
-      redirect_to session.url, allow_other_host: true, status: :see_other
+      if result.invalid_discount?
+        session.delete(:discount_code)
+        flash[:alert] = "Your discount code could not be applied. Please continue with your order."
+      end
+
+      session[:selected_address_id] = result.selected_address_id if result.selected_address_id.present?
+
+      redirect_to result.session.url, allow_other_host: true, status: :see_other
     rescue Stripe::StripeError => e
+      session.delete(:discount_code) if defined?(builder) && builder&.invalid_discount?
       Rails.logger.error("Stripe error: #{e.message}")
       flash[:error] = e.message
       redirect_to cart_path
@@ -178,9 +80,7 @@ class CheckoutsController < ApplicationController
       # Preload associations for order item creation (prevents N+1 queries)
       cart.cart_items.includes(CART_ITEM_INCLUDES).load
 
-      # Create the order
-      customer_details = stripe_session.customer_details
-      order = create_order_from_stripe_session(stripe_session, cart)
+      order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: cart).create
 
       # Emit checkout.completed event
       Rails.event.notify("checkout.completed",
@@ -234,130 +134,5 @@ class CheckoutsController < ApplicationController
 
   def cancel
     redirect_to cart_path, notice: "Checkout cancelled."
-  end
-
-  private
-
-  def create_order_from_stripe_session(stripe_session, cart)
-    customer_details = stripe_session.customer_details
-
-    # Use Stripe session amounts as source of truth (handles discounts correctly)
-    subtotal = stripe_session.amount_subtotal / 100.0
-    vat_amount = (stripe_session.total_details&.amount_tax || 0) / 100.0
-    discount_amount = (stripe_session.total_details&.amount_discount || 0) / 100.0
-    shipping_cost = (stripe_session.shipping_cost&.amount_total || 0) / 100.0
-    total_amount = stripe_session.amount_total / 100.0
-
-    # Extract discount code: prefer metadata (programmatic discount), fall back to
-    # customer-entered promotion code from Stripe session
-    discount_code = stripe_session.metadata&.[]("discount_code")
-    if discount_code.blank?
-      discount_code = extract_promotion_code(stripe_session)
-    end
-
-    # Extract shipping address details
-    shipping_address = extract_shipping_address(stripe_session)
-
-    if [ shipping_address[:name], shipping_address[:line1], shipping_address[:city], shipping_address[:postal_code], shipping_address[:country] ].any?(&:blank?)
-      raise "Shipping details are required"
-    end
-
-    # Get user for order
-    user = User.find_by(id: stripe_session.client_reference_id)
-
-    # Create the order
-    order = Order.create!(
-      user: user,
-      organization: user&.organization,
-      placed_by_user: user&.organization_id? ? user : nil,
-      email: customer_details.email,
-      stripe_session_id: stripe_session.id,
-      status: "paid",
-      subtotal_amount: subtotal,
-      vat_amount: vat_amount,
-      shipping_amount: shipping_cost,
-      total_amount: total_amount,
-      discount_amount: discount_amount,
-      discount_code: discount_code.presence,
-      shipping_name: shipping_address[:name],
-      shipping_address_line1: shipping_address[:line1],
-      shipping_address_line2: shipping_address[:line2],
-      shipping_city: shipping_address[:city],
-      shipping_postal_code: shipping_address[:postal_code],
-      shipping_country: shipping_address[:country]
-    )
-
-    # Set initial branded order status if cart contains configured items
-    if cart.cart_items.any?(&:configured?)
-      order.update!(branded_order_status: "design_pending")
-    end
-
-    # Create order items from cart items
-    cart.cart_items.each do |cart_item|
-      OrderItem.create_from_cart_item(cart_item, order).save!
-    end
-
-    order
-  end
-
-  def extract_shipping_address(stripe_session)
-    # Use with_indifferent_access for reliable key access (Stripe returns symbol keys)
-    # Requires Stripe API Clover release (2025-03-31+) where shipping_details
-    # moved to collected_information.shipping_details
-    # https://docs.stripe.com/changelog/basil/2025-03-31/checkout-session-remove-shipping-details
-    session_hash = stripe_session.to_hash.with_indifferent_access
-
-    shipping = session_hash.dig(:collected_information, :shipping_details)
-    return {} unless shipping
-
-    shipping = shipping.with_indifferent_access if shipping.respond_to?(:with_indifferent_access)
-    address = shipping[:address]
-    return {} unless address
-
-    address = address.with_indifferent_access if address.respond_to?(:with_indifferent_access)
-
-    {
-      name: shipping[:name],
-      line1: address[:line1],
-      line2: address[:line2],
-      city: address[:city],
-      postal_code: address[:postal_code],
-      country: address[:country]
-    }
-  end
-
-  def extract_promotion_code(stripe_session)
-    stripe_session
-      .total_details
-      &.breakdown
-      &.discounts
-      &.first
-      &.discount
-      &.promotion_code
-      &.code
-  rescue NoMethodError
-    nil
-  end
-
-  def tax_rate
-    @tax_rate ||= begin
-      # Try to find existing UK VAT tax rate to avoid creating duplicates
-      existing_rates = Stripe::TaxRate.list(active: true, limit: 100)
-      uk_vat_rate = existing_rates.data.find do |rate|
-        rate.percentage == 20.0 &&
-          rate.country == "GB" &&
-          rate.inclusive == false
-      end
-
-      # Use existing rate if found, otherwise create new one
-      uk_vat_rate || Stripe::TaxRate.create({
-        display_name: "VAT",
-        percentage: 20,
-        country: "GB",
-        jurisdiction: "United Kingdom",
-        description: "Value Added Tax",
-        inclusive: false
-      })
-    end
   end
 end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -8,6 +8,7 @@ class CheckoutsController < ApplicationController
 
   def create
     cart = Current.cart
+    builder = nil
 
     begin
       # Emit checkout.started event for funnel tracking
@@ -38,7 +39,7 @@ class CheckoutsController < ApplicationController
 
       redirect_to result.session.url, allow_other_host: true, status: :see_other
     rescue Stripe::StripeError => e
-      session.delete(:discount_code) if defined?(builder) && builder&.invalid_discount?
+      session.delete(:discount_code) if builder&.invalid_discount?
       Rails.logger.error("Stripe error: #{e.message}")
       flash[:error] = e.message
       redirect_to cart_path

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -75,9 +75,6 @@ class CheckoutsController < ApplicationController
         return redirect_to root_path
       end
 
-      # Preload associations for order item creation (prevents N+1 queries)
-      cart.cart_items.includes(Checkout::CART_ITEM_INCLUDES).load
-
       order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: cart).create
 
       # Emit checkout.completed event
@@ -126,6 +123,11 @@ class CheckoutsController < ApplicationController
       Rails.logger.error("Stripe error in checkout success: #{e.message}")
       Sentry.capture_exception(e, extra: { session_id: session_id })
       flash[:error] = "Unable to verify payment. Please contact support."
+      redirect_to cart_path
+    rescue Checkout::MissingShippingDetails => e
+      Rails.logger.warn("Missing shipping details in checkout success: #{e.message}")
+      Sentry.capture_exception(e, extra: { session_id: session_id })
+      flash[:error] = "Shipping details are required. Please try checkout again."
       redirect_to cart_path
     end
   end

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -3,9 +3,6 @@ class CheckoutsController < ApplicationController
   before_action :resume_session
   rate_limit to: 10, within: 1.minute, only: :create, with: -> { redirect_to cart_path, alert: "Too many checkout attempts. Please wait before trying again." }
 
-  # Eager loading strategy for cart items used across checkout methods
-  CART_ITEM_INCLUDES = [ :product, { design_attachment: :blob } ].freeze
-
   def create
     cart = Current.cart
     builder = nil
@@ -79,7 +76,7 @@ class CheckoutsController < ApplicationController
       end
 
       # Preload associations for order item creation (prevents N+1 queries)
-      cart.cart_items.includes(CART_ITEM_INCLUDES).load
+      cart.cart_items.includes(Checkout::CART_ITEM_INCLUDES).load
 
       order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: cart).create
 

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -119,7 +119,7 @@ module Webhooks
 
         # Create order items from cart items
         cart.cart_items.includes(:product, design_attachment: :blob).each do |cart_item|
-          OrderItem.create_from_cart_item(cart_item, order).save!
+          OrderItem.build_from_cart_item(cart_item, order).save!
         end
 
         # Clear the cart after successful order creation

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -192,6 +192,7 @@ module AnalyticsHelper
       tax: order.vat_amount.to_f,
       shipping: order.shipping_amount.to_f,
       currency: CURRENCY,
+      new_customer: order.new_customer?,
       items: items
     }
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -126,7 +126,8 @@ class Order < ApplicationRecord
 
   # Whether this is the customer's first completed purchase. Logged-in orders
   # deliberately match by either user_id or email so guest purchases can be
-  # recognized after a customer creates or uses an account.
+  # recognized after a customer creates or uses an account. This is a site-wide
+  # Google Ads customer signal, not an organization-scoped acquisition metric.
   def new_customer?
     scope = Order.where(status: %w[paid processing shipped delivered]).where.not(id: id)
     scope = scope.where(user_id: user_id).or(scope.where(email: email)) if user_id.present?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -124,8 +124,9 @@ class Order < ApplicationRecord
     reorder_schedule_id.present?
   end
 
-  # Whether this is the customer's first completed purchase, matched by
-  # user_id (if logged in) or email. Drives Google Ads new-customer bidding.
+  # Whether this is the customer's first completed purchase. Logged-in orders
+  # deliberately match by either user_id or email so guest purchases can be
+  # recognized after a customer creates or uses an account.
   def new_customer?
     scope = Order.where(status: %w[paid processing shipped delivered]).where.not(id: id)
     scope = scope.where(user_id: user_id).or(scope.where(email: email)) if user_id.present?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -124,6 +124,15 @@ class Order < ApplicationRecord
     reorder_schedule_id.present?
   end
 
+  # Whether this is the customer's first completed purchase, matched by
+  # user_id (if logged in) or email. Drives Google Ads new-customer bidding.
+  def new_customer?
+    scope = Order.where(status: %w[paid processing shipped delivered]).where.not(id: id)
+    scope = scope.where(user_id: user_id).or(scope.where(email: email)) if user_id.present?
+    scope = scope.where(email: email) if user_id.blank?
+    !scope.exists?
+  end
+
   private
 
   def generate_order_number

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -39,10 +39,6 @@ class OrderItem < ApplicationRecord
     order_item
   end
 
-  def self.create_from_cart_item(cart_item, order)
-    build_from_cart_item(cart_item, order)
-  end
-
   # Calculates subtotal: price * quantity
   # For standard products: price = pack price, quantity = number of packs
   # For branded products: price = unit price, quantity = number of units

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -17,7 +17,7 @@ class OrderItem < ApplicationRecord
   scope :samples, -> { where(is_sample: true) }
   scope :non_samples, -> { where(is_sample: false) }
 
-  def self.create_from_cart_item(cart_item, order)
+  def self.build_from_cart_item(cart_item, order)
     order_item = new(
       order: order,
       product: cart_item.product,
@@ -37,6 +37,10 @@ class OrderItem < ApplicationRecord
     end
 
     order_item
+  end
+
+  def self.create_from_cart_item(cart_item, order)
+    build_from_cart_item(cart_item, order)
   end
 
   # Calculates subtotal: price * quantity

--- a/app/services/checkout.rb
+++ b/app/services/checkout.rb
@@ -1,0 +1,3 @@
+module Checkout
+  CART_ITEM_INCLUDES = [ :product, { design_attachment: :blob } ].freeze
+end

--- a/app/services/checkout.rb
+++ b/app/services/checkout.rb
@@ -1,3 +1,5 @@
 module Checkout
   CART_ITEM_INCLUDES = [ :product, { design_attachment: :blob } ].freeze
+
+  class MissingShippingDetails < StandardError; end
 end

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -9,7 +9,7 @@ module Checkout
       order = Order.create!(order_attributes)
 
       cart_items.each do |cart_item|
-        OrderItem.create_from_cart_item(cart_item, order).save!
+        OrderItem.build_from_cart_item(cart_item, order).save!
       end
 
       order
@@ -52,7 +52,7 @@ module Checkout
     end
 
     def cart_items
-      @cart_items ||= cart.cart_items.includes(:product, { design_attachment: :blob }).load
+      @cart_items ||= cart.cart_items.includes(Checkout::CART_ITEM_INCLUDES).load
     end
 
     def user

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -6,7 +6,12 @@ module Checkout
     end
 
     def create
-      order = Order.create!(order_attributes)
+      shipping_address = extract_shipping_address
+      if required_shipping_values(shipping_address).any?(&:blank?)
+        raise Checkout::MissingShippingDetails, "Shipping details are required"
+      end
+
+      order = Order.create!(order_attributes(shipping_address))
 
       cart_items.each do |cart_item|
         OrderItem.build_from_cart_item(cart_item, order).save!
@@ -19,13 +24,7 @@ module Checkout
 
     attr_reader :stripe_session, :cart
 
-    def order_attributes
-      shipping_address = extract_shipping_address
-
-      if required_shipping_values(shipping_address).any?(&:blank?)
-        raise Checkout::MissingShippingDetails, "Shipping details are required"
-      end
-
+    def order_attributes(shipping_address)
       attributes = {
         user: user,
         organization: user&.organization,
@@ -98,6 +97,8 @@ module Checkout
     end
 
     def extract_promotion_code
+      # Stripe discount objects should follow this shape. Unexpected method
+      # errors are allowed to surface so checkout success failures are visible.
       stripe_session
         .total_details
         &.breakdown

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -20,7 +20,6 @@ module Checkout
     attr_reader :stripe_session, :cart
 
     def order_attributes
-      user = User.find_by(id: stripe_session.client_reference_id)
       shipping_address = extract_shipping_address
 
       if required_shipping_values(shipping_address).any?(&:blank?)
@@ -54,6 +53,12 @@ module Checkout
 
     def cart_items
       @cart_items ||= cart.cart_items.includes(:product, { design_attachment: :blob }).load
+    end
+
+    def user
+      return @user if defined?(@user)
+
+      @user = User.find_by(id: stripe_session.client_reference_id)
     end
 
     def required_shipping_values(shipping_address)

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -8,11 +8,7 @@ module Checkout
     def create
       order = Order.create!(order_attributes)
 
-      if cart.cart_items.any?(&:configured?)
-        order.update!(branded_order_status: "design_pending")
-      end
-
-      cart.cart_items.each do |cart_item|
+      cart_items.each do |cart_item|
         OrderItem.create_from_cart_item(cart_item, order).save!
       end
 
@@ -31,7 +27,7 @@ module Checkout
         raise "Shipping details are required"
       end
 
-      {
+      attributes = {
         user: user,
         organization: user&.organization,
         placed_by_user: user&.organization_id? ? user : nil,
@@ -51,6 +47,13 @@ module Checkout
         shipping_postal_code: shipping_address[:postal_code],
         shipping_country: shipping_address[:country]
       }
+
+      attributes[:branded_order_status] = "design_pending" if cart_items.any?(&:configured?)
+      attributes
+    end
+
+    def cart_items
+      @cart_items ||= cart.cart_items.includes(:product, { design_attachment: :blob }).load
     end
 
     def required_shipping_values(shipping_address)

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -11,13 +11,15 @@ module Checkout
         raise Checkout::MissingShippingDetails, "Shipping details are required"
       end
 
-      order = Order.create!(order_attributes(shipping_address))
+      ApplicationRecord.transaction do
+        order = Order.create!(order_attributes(shipping_address))
 
-      cart_items.each do |cart_item|
-        OrderItem.build_from_cart_item(cart_item, order).save!
+        cart_items.each do |cart_item|
+          OrderItem.build_from_cart_item(cart_item, order).save!
+        end
+
+        order
       end
-
-      order
     end
 
     private

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -1,0 +1,105 @@
+module Checkout
+  class OrderCreator
+    def initialize(stripe_session:, cart:)
+      @stripe_session = stripe_session
+      @cart = cart
+    end
+
+    def create
+      order = Order.create!(order_attributes)
+
+      if cart.cart_items.any?(&:configured?)
+        order.update!(branded_order_status: "design_pending")
+      end
+
+      cart.cart_items.each do |cart_item|
+        OrderItem.create_from_cart_item(cart_item, order).save!
+      end
+
+      order
+    end
+
+    private
+
+    attr_reader :stripe_session, :cart
+
+    def order_attributes
+      user = User.find_by(id: stripe_session.client_reference_id)
+      shipping_address = extract_shipping_address
+
+      if required_shipping_values(shipping_address).any?(&:blank?)
+        raise "Shipping details are required"
+      end
+
+      {
+        user: user,
+        organization: user&.organization,
+        placed_by_user: user&.organization_id? ? user : nil,
+        email: stripe_session.customer_details.email,
+        stripe_session_id: stripe_session.id,
+        status: "paid",
+        subtotal_amount: stripe_session.amount_subtotal / 100.0,
+        vat_amount: (stripe_session.total_details&.amount_tax || 0) / 100.0,
+        shipping_amount: (stripe_session.shipping_cost&.amount_total || 0) / 100.0,
+        total_amount: stripe_session.amount_total / 100.0,
+        discount_amount: (stripe_session.total_details&.amount_discount || 0) / 100.0,
+        discount_code: discount_code.presence,
+        shipping_name: shipping_address[:name],
+        shipping_address_line1: shipping_address[:line1],
+        shipping_address_line2: shipping_address[:line2],
+        shipping_city: shipping_address[:city],
+        shipping_postal_code: shipping_address[:postal_code],
+        shipping_country: shipping_address[:country]
+      }
+    end
+
+    def required_shipping_values(shipping_address)
+      [
+        shipping_address[:name],
+        shipping_address[:line1],
+        shipping_address[:city],
+        shipping_address[:postal_code],
+        shipping_address[:country]
+      ]
+    end
+
+    def discount_code
+      stripe_session.metadata&.[]("discount_code").presence || extract_promotion_code
+    end
+
+    def extract_shipping_address
+      session_hash = stripe_session.to_hash.with_indifferent_access
+
+      shipping = session_hash.dig(:collected_information, :shipping_details)
+      return {} unless shipping
+
+      shipping = shipping.with_indifferent_access if shipping.respond_to?(:with_indifferent_access)
+      address = shipping[:address]
+      return {} unless address
+
+      address = address.with_indifferent_access if address.respond_to?(:with_indifferent_access)
+
+      {
+        name: shipping[:name],
+        line1: address[:line1],
+        line2: address[:line2],
+        city: address[:city],
+        postal_code: address[:postal_code],
+        country: address[:country]
+      }
+    end
+
+    def extract_promotion_code
+      stripe_session
+        .total_details
+        &.breakdown
+        &.discounts
+        &.first
+        &.discount
+        &.promotion_code
+        &.code
+    rescue NoMethodError
+      nil
+    end
+  end
+end

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -23,7 +23,7 @@ module Checkout
       shipping_address = extract_shipping_address
 
       if required_shipping_values(shipping_address).any?(&:blank?)
-        raise "Shipping details are required"
+        raise Checkout::MissingShippingDetails, "Shipping details are required"
       end
 
       attributes = {
@@ -106,8 +106,6 @@ module Checkout
         &.discount
         &.promotion_code
         &.code
-    rescue NoMethodError
-      nil
     end
   end
 end

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -79,8 +79,9 @@ module Checkout
 
     def stripe_quantity(item)
       return 1 if item.sample? || item.configured?
-      return item.quantity if item.product.pac_size.blank? || item.product.pac_size.zero?
+      return item.quantity if unit_priced?(item)
 
+      # Pack-priced items fold pack count into unit_amount for one Stripe subtotal.
       1
     end
 
@@ -89,7 +90,7 @@ module Checkout
         0
       elsif item.configured?
         (item.price.to_f * item.quantity * 100).round
-      elsif item.product.pac_size.blank? || item.product.pac_size.zero?
+      elsif unit_priced?(item)
         (item.price.to_f * 100).round
       else
         # Pack-priced items use one Stripe line item with the pack count folded
@@ -106,12 +107,16 @@ module Checkout
       elsif item.configured?
         units_formatted = ActiveSupport::NumberHelper.number_to_delimited(item.quantity)
         "#{product.generated_title} - #{item.configuration['size']} (#{units_formatted} units)"
-      elsif product.pac_size.blank? || product.pac_size.zero?
+      elsif unit_priced?(item)
         product.generated_title
       else
         packs_label = item.quantity == 1 ? "pack" : "packs"
         "#{product.generated_title} (#{item.quantity} #{packs_label})"
       end
+    end
+
+    def unit_priced?(item)
+      item.product.pac_size.blank? || item.product.pac_size.zero?
     end
 
     def shipping_options

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -1,0 +1,173 @@
+module Checkout
+  class SessionBuilder
+    CART_ITEM_INCLUDES = [ :product, { design_attachment: :blob } ].freeze
+
+    Result = Struct.new(:session, :invalid_discount_code, :selected_address_id, keyword_init: true) do
+      def invalid_discount?
+        invalid_discount_code.present?
+      end
+    end
+
+    def initialize(cart:, user:, address_id:, discount_code:, datafast_visitor_id:, datafast_session_id:, success_url:, cancel_url:)
+      @cart = cart
+      @user = user
+      @address_id = address_id
+      @discount_code = discount_code
+      @datafast_visitor_id = datafast_visitor_id
+      @datafast_session_id = datafast_session_id
+      @success_url = success_url
+      @cancel_url = cancel_url
+    end
+
+    attr_reader :invalid_discount_code, :selected_address_id
+
+    def invalid_discount?
+      invalid_discount_code.present?
+    end
+
+    def create
+      session_params = build_session_params
+      @invalid_discount_code = apply_discount(session_params)
+      @selected_address_id = apply_customer_details(session_params)
+
+      Result.new(
+        session: Stripe::Checkout::Session.create(session_params),
+        invalid_discount_code: invalid_discount_code,
+        selected_address_id: selected_address_id
+      )
+    end
+
+    private
+
+    attr_reader :cart, :user, :address_id, :discount_code, :datafast_visitor_id, :datafast_session_id, :success_url, :cancel_url
+
+    def build_session_params
+      {
+        payment_method_types: [ "card" ],
+        line_items: line_items,
+        mode: "payment",
+        shipping_address_collection: {
+          allowed_countries: Shipping::ALLOWED_COUNTRIES
+        },
+        shipping_options: shipping_options,
+        success_url: success_url,
+        cancel_url: cancel_url,
+        metadata: {
+          cart_id: cart.id.to_s,
+          discount_code: discount_code,
+          datafast_visitor_id: datafast_visitor_id,
+          datafast_session_id: datafast_session_id
+        }
+      }
+    end
+
+    def line_items
+      cart.cart_items.includes(CART_ITEM_INCLUDES).map do |item|
+        {
+          quantity: stripe_quantity(item),
+          price_data: {
+            currency: "gbp",
+            product_data: {
+              name: product_name(item)
+            },
+            unit_amount: unit_amount(item),
+            tax_behavior: "exclusive"
+          },
+          tax_rates: [ tax_rate.id ]
+        }
+      end
+    end
+
+    def stripe_quantity(item)
+      return 1 if item.sample? || item.configured?
+      return item.quantity if item.product.pac_size.blank? || item.product.pac_size.zero?
+
+      1
+    end
+
+    def unit_amount(item)
+      if item.sample?
+        0
+      elsif item.configured?
+        (item.price.to_f * item.quantity * 100).round
+      elsif item.product.pac_size.blank? || item.product.pac_size.zero?
+        (item.price.to_f * 100).round
+      else
+        (item.price.to_f * item.quantity * 100).round
+      end
+    end
+
+    def product_name(item)
+      product = item.product
+
+      if item.sample?
+        "#{product.generated_title} (Sample)"
+      elsif item.configured?
+        units_formatted = ActiveSupport::NumberHelper.number_to_delimited(item.quantity)
+        "#{product.generated_title} - #{item.configuration['size']} (#{units_formatted} units)"
+      elsif product.pac_size.blank? || product.pac_size.zero?
+        product.generated_title
+      else
+        packs_label = item.quantity == 1 ? "pack" : "packs"
+        "#{product.generated_title} (#{item.quantity} #{packs_label})"
+      end
+    end
+
+    def shipping_options
+      if cart.only_samples?
+        [ Shipping.sample_only_shipping_option ]
+      else
+        Shipping.shipping_options_for_subtotal(cart.subtotal_amount)
+      end
+    end
+
+    def apply_discount(session_params)
+      if discount_code.present?
+        apply_session_discount(session_params)
+      else
+        session_params[:allow_promotion_codes] = true
+        nil
+      end
+    end
+
+    def apply_session_discount(session_params)
+      Stripe::Coupon.retrieve(discount_code)
+      session_params[:discounts] = [ { coupon: discount_code } ]
+      nil
+    rescue Stripe::InvalidRequestError => e
+      Rails.logger.warn("Invalid discount coupon '#{discount_code}': #{e.message}")
+      session_params[:metadata][:discount_code] = nil
+      session_params[:allow_promotion_codes] = true
+      discount_code
+    end
+
+    def apply_customer_details(session_params)
+      return nil unless user
+
+      session_params[:client_reference_id] = user.id
+
+      if address_id.present?
+        apply_selected_address(session_params)
+      else
+        session_params[:customer_email] = user.email_address
+        nil
+      end
+    end
+
+    def apply_selected_address(session_params)
+      address = user.addresses.find_by(id: address_id)
+      unless address
+        session_params[:customer_email] = user.email_address
+        return nil
+      end
+
+      user.sync_stripe_customer!(address: address)
+      session_params[:customer] = user.stripe_customer_id
+      address_id
+    end
+
+    def tax_rate
+      @tax_rate ||= StripeTaxRateProvider.new.tax_rate
+    end
+  end
+end

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -21,6 +21,8 @@ module Checkout
 
     attr_reader :invalid_discount_code, :selected_address_id
 
+    # Mirrors Result#invalid_discount? so the controller can clean up session
+    # state even when Stripe::Checkout::Session.create raises after validation.
     def invalid_discount?
       invalid_discount_code.present?
     end
@@ -93,6 +95,8 @@ module Checkout
       elsif item.product.pac_size.blank? || item.product.pac_size.zero?
         (item.price.to_f * 100).round
       else
+        # Pack-priced items use one Stripe line item with the pack count folded
+        # into unit_amount, so Stripe's tax/discount math sees one subtotal.
         (item.price.to_f * item.quantity * 100).round
       end
     end

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -19,8 +19,6 @@ module Checkout
       @cancel_url = cancel_url
     end
 
-    attr_reader :invalid_discount_code, :selected_address_id
-
     # Mirrors Result#invalid_discount? so the controller can clean up session
     # state even when Stripe::Checkout::Session.create raises after validation.
     def invalid_discount?
@@ -41,7 +39,8 @@ module Checkout
 
     private
 
-    attr_reader :cart, :user, :address_id, :discount_code, :datafast_visitor_id, :datafast_session_id, :success_url, :cancel_url
+    attr_reader :cart, :user, :address_id, :discount_code, :datafast_visitor_id, :datafast_session_id, :success_url,
+                :cancel_url, :invalid_discount_code, :selected_address_id
 
     def build_session_params
       {
@@ -140,7 +139,8 @@ module Checkout
       nil
     rescue Stripe::InvalidRequestError => e
       Rails.logger.warn("Invalid discount coupon '#{discount_code}': #{e.message}")
-      session_params[:metadata][:discount_code] = nil
+      # Do not persist unusable customer input to Stripe metadata.
+      session_params[:metadata].delete(:discount_code)
       session_params[:allow_promotion_codes] = true
       discount_code
     end

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -1,7 +1,5 @@
 module Checkout
   class SessionBuilder
-    CART_ITEM_INCLUDES = [ :product, { design_attachment: :blob } ].freeze
-
     Result = Struct.new(:session, :invalid_discount_code, :selected_address_id, keyword_init: true) do
       def invalid_discount?
         invalid_discount_code.present?
@@ -63,7 +61,7 @@ module Checkout
     end
 
     def line_items
-      cart.cart_items.includes(CART_ITEM_INCLUDES).map do |item|
+      cart.cart_items.includes(Checkout::CART_ITEM_INCLUDES).map do |item|
         {
           quantity: stripe_quantity(item),
           price_data: {

--- a/app/services/checkout/stripe_tax_rate_provider.rb
+++ b/app/services/checkout/stripe_tax_rate_provider.rb
@@ -1,10 +1,25 @@
 module Checkout
   class StripeTaxRateProvider
+    UK_VAT_RATE_ID_CACHE_KEY = "checkout/stripe_tax_rate_provider/uk_vat_rate_id"
+    UK_VAT_RATE_ID_CACHE_TTL = 1.hour
+    TaxRateReference = Struct.new(:id)
+
     def tax_rate
-      @tax_rate ||= find_or_create_uk_vat_rate
+      @tax_rate ||= cached_tax_rate || fetch_and_cache_tax_rate
     end
 
     private
+
+    def cached_tax_rate
+      tax_rate_id = Rails.cache.read(UK_VAT_RATE_ID_CACHE_KEY)
+      TaxRateReference.new(tax_rate_id) if tax_rate_id.present?
+    end
+
+    def fetch_and_cache_tax_rate
+      find_or_create_uk_vat_rate.tap do |tax_rate|
+        Rails.cache.write(UK_VAT_RATE_ID_CACHE_KEY, tax_rate.id, expires_in: UK_VAT_RATE_ID_CACHE_TTL)
+      end
+    end
 
     def find_or_create_uk_vat_rate
       existing_rates = Stripe::TaxRate.list(active: true, limit: 100)

--- a/app/services/checkout/stripe_tax_rate_provider.rb
+++ b/app/services/checkout/stripe_tax_rate_provider.rb
@@ -29,6 +29,9 @@ module Checkout
           rate.inclusive == false
       end
 
+      # Stripe has no uniqueness constraint for equivalent tax rates. The cache
+      # avoids repeated lookups after the first winner, accepting a small
+      # duplicate-create race window during a cold cache.
       uk_vat_rate || Stripe::TaxRate.create({
         display_name: "VAT",
         percentage: 20,

--- a/app/services/checkout/stripe_tax_rate_provider.rb
+++ b/app/services/checkout/stripe_tax_rate_provider.rb
@@ -1,0 +1,27 @@
+module Checkout
+  class StripeTaxRateProvider
+    def tax_rate
+      @tax_rate ||= find_or_create_uk_vat_rate
+    end
+
+    private
+
+    def find_or_create_uk_vat_rate
+      existing_rates = Stripe::TaxRate.list(active: true, limit: 100)
+      uk_vat_rate = existing_rates.data.find do |rate|
+        rate.percentage == 20.0 &&
+          rate.country == "GB" &&
+          rate.inclusive == false
+      end
+
+      uk_vat_rate || Stripe::TaxRate.create({
+        display_name: "VAT",
+        percentage: 20,
+        country: "GB",
+        jurisdiction: "United Kingdom",
+        description: "Value Added Tax",
+        inclusive: false
+      })
+    end
+  end
+end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,7 +7,7 @@
 %>
 
 <% content_for :title do %>
-<%= @product.meta_title.presence || @product.generated_meta_title %>
+<%= @product.meta_title.presence || "#{@product.generated_meta_title} | #{@product.category.name} | Afida" %>
 <% end %>
 
 <% content_for :meta_description do %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -7,7 +7,7 @@
 %>
 
 <% content_for :title do %>
-<%= @product.meta_title.presence || "#{@product.generated_meta_title} | #{@product.category.name} | Afida" %>
+<%= @product.meta_title.presence || @product.generated_meta_title %>
 <% end %>
 
 <% content_for :meta_description do %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -35,6 +35,8 @@ Rails.application.configure do
                        "https://www.google-analytics.com",
                        "https://analytics.google.com",
                        "https://www.googletagmanager.com",
+                       "https://www.googleadservices.com",
+                       "https://googleads.g.doubleclick.net",
                        "https://datafa.st",
                        "https://*.sentry.io"
 

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -570,6 +570,24 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil flash[:error]
   end
 
+  test "create clears invalid discount before handling later Stripe session errors" do
+    post email_subscriptions_path, params: { email: "invalid-discount@example.com" }
+    assert_equal "WELCOME5", session[:discount_code]
+
+    Stripe::Coupon.stubs(:retrieve).raises(
+      Stripe::InvalidRequestError.new("No such coupon", nil)
+    )
+    Stripe::Checkout::Session.stubs(:create).raises(
+      StripeErrors.api_error
+    )
+
+    post checkout_path
+
+    assert_nil session[:discount_code]
+    assert_redirected_to cart_path
+    assert_not_nil flash[:error]
+  end
+
   test "create handles Stripe invalid request errors" do
     Stripe::Checkout::Session.stubs(:create).raises(
       StripeErrors.invalid_request("Invalid line items")

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -637,7 +637,7 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "success validates required shipping details presence" do
+  test "success handles missing shipping details with checkout retry" do
     # Use the helper with nil line1 to test validation
     session = build_stripe_session(
       id: "sess_test_missing_address",
@@ -646,9 +646,12 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     )
     Stripe::Checkout::Session.stubs(:retrieve).returns(session)
 
-    assert_raises(RuntimeError, "Shipping details are required") do
+    assert_no_difference "Order.count" do
       get success_checkout_path, params: { session_id: session.id }
     end
+
+    assert_redirected_to cart_path
+    assert_match /Shipping details are required/, flash[:error]
   end
 
   test "create respects rate limiting" do

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -99,6 +99,16 @@ class AnalyticsHelperTest < ActionView::TestCase
     Rails.application.config.x.gtm_container_id = nil
   end
 
+  test "ecommerce_purchase_event includes new_customer flag" do
+    Rails.application.config.x.gtm_container_id = "GTM-TEST123"
+
+    result = ecommerce_purchase_event(@order)
+
+    assert_includes result, '"new_customer"'
+
+    Rails.application.config.x.gtm_container_id = nil
+  end
+
   test "ecommerce_purchase_event includes coupon and discount when discount applied" do
     Rails.application.config.x.gtm_container_id = "GTM-TEST123"
     @order.update!(discount_amount: 3.57, discount_code: "WELCOME5")

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -104,7 +104,7 @@ class AnalyticsHelperTest < ActionView::TestCase
 
     result = ecommerce_purchase_event(@order)
 
-    assert_includes result, '"new_customer"'
+    assert_includes result, %("new_customer":#{@order.new_customer?})
 
     Rails.application.config.x.gtm_container_id = nil
   end

--- a/test/helpers/analytics_helper_test.rb
+++ b/test/helpers/analytics_helper_test.rb
@@ -102,9 +102,13 @@ class AnalyticsHelperTest < ActionView::TestCase
   test "ecommerce_purchase_event includes new_customer flag" do
     Rails.application.config.x.gtm_container_id = "GTM-TEST123"
 
+    @order.stubs(:new_customer?).returns(true)
     result = ecommerce_purchase_event(@order)
+    assert_includes result, '"new_customer":true'
 
-    assert_includes result, %("new_customer":#{@order.new_customer?})
+    @order.stubs(:new_customer?).returns(false)
+    result = ecommerce_purchase_event(@order)
+    assert_includes result, '"new_customer":false'
 
     Rails.application.config.x.gtm_container_id = nil
   end

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
+  test "connect-src allows Google Ads conversion endpoints" do
+    get root_url
+    csp = response.headers["Content-Security-Policy"] || response.headers["Content-Security-Policy-Report-Only"]
+    connect_src = csp.split(";").find { |d| d.strip.start_with?("connect-src") }
+
+    assert_includes connect_src, "https://www.googleadservices.com"
+    assert_includes connect_src, "https://googleads.g.doubleclick.net"
+  end
+end

--- a/test/integration/product_meta_tags_test.rb
+++ b/test/integration/product_meta_tags_test.rb
@@ -14,7 +14,7 @@ class ProductMetaTagsTest < ActionDispatch::IntegrationTest
     product.update(meta_title: nil)
 
     get product_path(product)
-    assert_select "title", "#{product.generated_title} | #{product.category.name} | Afida"
+    assert_select "title", product.generated_meta_title
   end
 
   test "uses custom meta_description when present" do

--- a/test/models/order_item_test.rb
+++ b/test/models/order_item_test.rb
@@ -236,6 +236,10 @@ class OrderItemTest < ActiveSupport::TestCase
     assert_equal cart_item.quantity, order_item.quantity
   end
 
+  test "does not expose create_from_cart_item alias because build result is unsaved" do
+    assert_not_respond_to OrderItem, :create_from_cart_item
+  end
+
   test "order item stores configuration from cart item" do
     cart_item = cart_items(:branded_configuration)
     order = orders(:acme_order)

--- a/test/models/order_item_test.rb
+++ b/test/models/order_item_test.rb
@@ -224,11 +224,23 @@ class OrderItemTest < ActiveSupport::TestCase
   end
 
   # Configuration tests
+  test "build_from_cart_item returns an unsaved order item snapshot" do
+    cart_item = cart_items(:one)
+    order = orders(:one)
+
+    order_item = OrderItem.build_from_cart_item(cart_item, order)
+
+    assert_not order_item.persisted?
+    assert_equal order, order_item.order
+    assert_equal cart_item.product, order_item.product
+    assert_equal cart_item.quantity, order_item.quantity
+  end
+
   test "order item stores configuration from cart item" do
     cart_item = cart_items(:branded_configuration)
     order = orders(:acme_order)
 
-    order_item = OrderItem.create_from_cart_item(cart_item, order)
+    order_item = OrderItem.build_from_cart_item(cart_item, order)
 
     assert_equal cart_item.configuration["size"], order_item.configuration["size"]
     assert_equal cart_item.configuration["quantity"], order_item.configuration["quantity"]
@@ -255,7 +267,7 @@ class OrderItemTest < ActiveSupport::TestCase
       price: BigDecimal("12.07")
     )
 
-    order_item = OrderItem.create_from_cart_item(cart_item, @order)
+    order_item = OrderItem.build_from_cart_item(cart_item, @order)
 
     assert_equal 50, order_item.pac_size
   end

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -543,6 +543,45 @@ class OrderTest < ActiveSupport::TestCase
     assert_not logged_in_order.new_customer?
   end
 
+  test "new_customer? returns true for logged-in user when only a different guest email exists" do
+    user = users(:user_without_orders)
+    Order.create!(@valid_attributes.merge(
+      user: nil,
+      email: "other-guest@example.com",
+      stripe_session_id: "sess_other_guest_email",
+      order_number: nil,
+      status: "paid"
+    ))
+    logged_in_order = Order.create!(@valid_attributes.merge(
+      user: user,
+      email: user.email_address,
+      stripe_session_id: "sess_logged_in_new_email",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert logged_in_order.new_customer?
+  end
+
+  test "new_customer? treats matching email in another organization as returning for Google Ads" do
+    Order.create!(@valid_attributes.merge(
+      organization: organizations(:acme),
+      email: "shared-buyer@example.com",
+      stripe_session_id: "sess_org_a_buyer",
+      order_number: nil,
+      status: "paid"
+    ))
+    later = Order.create!(@valid_attributes.merge(
+      organization: organizations(:bobs_bakery),
+      email: "shared-buyer@example.com",
+      stripe_session_id: "sess_org_b_buyer",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert_not later.new_customer?
+  end
+
   test "new_customer? ignores pending and cancelled prior orders" do
     Order.create!(@valid_attributes.merge(
       email: "abandoned@example.com",

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -505,6 +505,13 @@ class OrderTest < ActiveSupport::TestCase
 
   test "new_customer? returns false for logged-in user's second order" do
     user = users(:one)
+    Order.create!(@valid_attributes.merge(
+      user: user,
+      email: "first-user-order@example.com",
+      stripe_session_id: "sess_user_first",
+      order_number: nil,
+      status: "paid"
+    ))
     second = Order.create!(@valid_attributes.merge(
       user: user,
       email: "different-email@example.com",
@@ -514,6 +521,26 @@ class OrderTest < ActiveSupport::TestCase
     ))
 
     assert_not second.new_customer?
+  end
+
+  test "new_customer? returns false for logged-in user with prior guest order at same email" do
+    user = users(:one)
+    Order.create!(@valid_attributes.merge(
+      user: nil,
+      email: user.email_address,
+      stripe_session_id: "sess_guest_before_account",
+      order_number: nil,
+      status: "paid"
+    ))
+    logged_in_order = Order.create!(@valid_attributes.merge(
+      user: user,
+      email: user.email_address,
+      stripe_session_id: "sess_logged_in_after_guest",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert_not logged_in_order.new_customer?
   end
 
   test "new_customer? ignores pending and cancelled prior orders" do

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -473,4 +473,80 @@ class OrderTest < ActiveSupport::TestCase
 
     assert_not order.sample_request?
   end
+
+  # new_customer? tests
+  test "new_customer? returns true for guest with no prior orders for email" do
+    order = Order.create!(@valid_attributes.merge(
+      email: "brand-new@example.com",
+      stripe_session_id: "sess_new_guest",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert order.new_customer?
+  end
+
+  test "new_customer? returns false for guest with prior paid order at same email" do
+    Order.create!(@valid_attributes.merge(
+      email: "repeat@example.com",
+      stripe_session_id: "sess_prior",
+      order_number: nil,
+      status: "paid"
+    ))
+    later = Order.create!(@valid_attributes.merge(
+      email: "repeat@example.com",
+      stripe_session_id: "sess_later",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert_not later.new_customer?
+  end
+
+  test "new_customer? returns false for logged-in user's second order" do
+    user = users(:one)
+    second = Order.create!(@valid_attributes.merge(
+      user: user,
+      email: "different-email@example.com",
+      stripe_session_id: "sess_user_second",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert_not second.new_customer?
+  end
+
+  test "new_customer? ignores pending and cancelled prior orders" do
+    Order.create!(@valid_attributes.merge(
+      email: "abandoned@example.com",
+      stripe_session_id: "sess_pending",
+      order_number: nil,
+      status: "pending"
+    ))
+    Order.create!(@valid_attributes.merge(
+      email: "abandoned@example.com",
+      stripe_session_id: "sess_cancelled",
+      order_number: nil,
+      status: "cancelled"
+    ))
+    current = Order.create!(@valid_attributes.merge(
+      email: "abandoned@example.com",
+      stripe_session_id: "sess_current",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert current.new_customer?
+  end
+
+  test "new_customer? does not count the order itself" do
+    order = Order.create!(@valid_attributes.merge(
+      email: "self@example.com",
+      stripe_session_id: "sess_self",
+      order_number: nil,
+      status: "paid"
+    ))
+
+    assert order.new_customer?
+  end
 end

--- a/test/services/checkout/order_creator_test.rb
+++ b/test/services/checkout/order_creator_test.rb
@@ -73,7 +73,17 @@ class Checkout::OrderCreatorTest < ActiveSupport::TestCase
       shipping_address: { line1: nil, line2: "Flat 4", city: "London", postal_code: "SW1A 1AA", country: "GB" }
     )
 
-    assert_raises(RuntimeError, "Shipping details are required") do
+    error = assert_raises(Checkout::MissingShippingDetails) do
+      Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+    end
+    assert_equal "Shipping details are required", error.message
+  end
+
+  test "propagates unexpected Stripe promotion code shapes" do
+    stripe_session = build_stripe_session
+    stripe_session.total_details.stubs(:breakdown).raises(NoMethodError.new("unexpected shape"))
+
+    assert_raises(NoMethodError) do
       Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
     end
   end

--- a/test/services/checkout/order_creator_test.rb
+++ b/test/services/checkout/order_creator_test.rb
@@ -47,6 +47,27 @@ class Checkout::OrderCreatorTest < ActiveSupport::TestCase
     assert_equal 5.0, order.discount_amount.to_f
   end
 
+  test "marks orders with configured products as design pending" do
+    @cart.cart_items.destroy_all
+    cart_item = @cart.cart_items.build(
+      product: products(:branded_template_variant),
+      quantity: 5000,
+      price: 0.20,
+      configuration: { size: "12oz", quantity: 5000 },
+      calculated_price: 1000.00
+    )
+    cart_item.design.attach(
+      io: StringIO.new("fake design content"),
+      filename: "design.pdf",
+      content_type: "application/pdf"
+    )
+    cart_item.save!
+
+    order = Checkout::OrderCreator.new(stripe_session: build_stripe_session, cart: @cart).create
+
+    assert_equal "design_pending", order.branded_order_status
+  end
+
   test "requires shipping details from collected information" do
     stripe_session = build_stripe_session(
       shipping_address: { line1: nil, line2: "Flat 4", city: "London", postal_code: "SW1A 1AA", country: "GB" }

--- a/test/services/checkout/order_creator_test.rb
+++ b/test/services/checkout/order_creator_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Checkout::OrderCreatorTest < ActiveSupport::TestCase
+  include StripeTestHelper
+
+  setup do
+    @cart = Cart.create!
+    @cart_item = @cart.cart_items.create!(product: products(:one), quantity: 2, price: 10.00)
+  end
+
+  test "creates paid order from Stripe amounts and cart items" do
+    stripe_session = build_stripe_session(
+      customer_email: "buyer@example.com",
+      amount_subtotal: 2000,
+      amount_tax: 400,
+      shipping_amount_total: 699,
+      amount_total: 3099
+    )
+
+    assert_difference [ "Order.count", "OrderItem.count" ], 1 do
+      @order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+    end
+
+    assert_equal "buyer@example.com", @order.email
+    assert_equal "paid", @order.status
+    assert_equal 20.0, @order.subtotal_amount.to_f
+    assert_equal 4.0, @order.vat_amount.to_f
+    assert_equal 6.99, @order.shipping_amount.to_f
+    assert_equal 30.99, @order.total_amount.to_f
+
+    order_item = @order.order_items.first
+    assert_equal @cart_item.product, order_item.product
+    assert_equal @cart_item.quantity, order_item.quantity
+    assert_equal @cart_item.price, order_item.price
+  end
+
+  test "stores promotion code from Stripe discount breakdown" do
+    stripe_session = build_stripe_session(
+      customer_email: "buyer@example.com",
+      amount_discount: 500,
+      promotion_code: "SUMMER20"
+    )
+
+    order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+
+    assert_equal "SUMMER20", order.discount_code
+    assert_equal 5.0, order.discount_amount.to_f
+  end
+
+  test "requires shipping details from collected information" do
+    stripe_session = build_stripe_session(
+      shipping_address: { line1: nil, line2: "Flat 4", city: "London", postal_code: "SW1A 1AA", country: "GB" }
+    )
+
+    assert_raises(RuntimeError, "Shipping details are required") do
+      Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+    end
+  end
+end

--- a/test/services/checkout/order_creator_test.rb
+++ b/test/services/checkout/order_creator_test.rb
@@ -79,6 +79,17 @@ class Checkout::OrderCreatorTest < ActiveSupport::TestCase
     assert_equal "Shipping details are required", error.message
   end
 
+  test "rolls back order when an order item cannot be saved" do
+    stripe_session = build_stripe_session(customer_email: "buyer@example.com")
+    OrderItem.any_instance.stubs(:save!).raises(ActiveRecord::RecordInvalid.new(OrderItem.new))
+
+    assert_no_difference [ "Order.count", "OrderItem.count" ] do
+      assert_raises(ActiveRecord::RecordInvalid) do
+        Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+      end
+    end
+  end
+
   test "propagates unexpected Stripe promotion code shapes" do
     stripe_session = build_stripe_session
     stripe_session.total_details.stubs(:breakdown).raises(NoMethodError.new("unexpected shape"))

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class Checkout::SessionBuilderTest < ActiveSupport::TestCase
+  include StripeTestHelper
+
+  setup do
+    @cart = Cart.create!
+    @success_url = "https://example.com/checkout/success?session_id={CHECKOUT_SESSION_ID}"
+    @cancel_url = "https://example.com/checkout/cancel"
+    stub_stripe_tax_rate_list
+  end
+
+  test "builds pack-priced line items with pack count folded into one Stripe subtotal" do
+    @cart.cart_items.create!(product: products(:paper_lid_80mm), quantity: 2, price: 45.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_session
+
+    line_item = captured_params[:line_items].first
+    assert_equal 1, line_item[:quantity]
+    assert_equal 9000, line_item[:price_data][:unit_amount]
+    assert_match "(2 packs)", line_item[:price_data][:product_data][:name]
+  end
+
+  test "builds configured line items as one Stripe subtotal with units in product name" do
+    cart_item = @cart.cart_items.build(
+      product: products(:branded_template_variant),
+      quantity: 5000,
+      price: 0.20,
+      configuration: { size: "12oz", quantity: 5000 },
+      calculated_price: 1000.00
+    )
+    cart_item.design.attach(
+      io: StringIO.new("fake design content"),
+      filename: "design.pdf",
+      content_type: "application/pdf"
+    )
+    cart_item.save!
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_session
+
+    line_item = captured_params[:line_items].first
+    assert_equal 1, line_item[:quantity]
+    assert_equal 100_000, line_item[:price_data][:unit_amount]
+    assert_match "12oz (5,000 units)", line_item[:price_data][:product_data][:name]
+  end
+
+  test "marks invalid session discount while still allowing customer promotion codes" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+    Stripe::Coupon.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("No such coupon", nil))
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    result = build_session(discount_code: "WELCOME5")
+
+    assert result.invalid_discount?
+    assert_equal true, captured_params[:allow_promotion_codes]
+    assert_nil captured_params[:metadata][:discount_code]
+  end
+
+  private
+
+  def build_session(discount_code: nil)
+    Checkout::SessionBuilder.new(
+      cart: @cart,
+      user: nil,
+      address_id: nil,
+      discount_code: discount_code,
+      datafast_visitor_id: nil,
+      datafast_session_id: nil,
+      success_url: @success_url,
+      cancel_url: @cancel_url
+    ).create
+  end
+end

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -56,6 +56,23 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
     assert_match "12oz (5,000 units)", line_item[:price_data][:product_data][:name]
   end
 
+  test "builds guest checkout session without customer details" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    result = build_session
+
+    assert_nil result.selected_address_id
+    assert_nil captured_params[:customer]
+    assert_nil captured_params[:customer_email]
+    assert_nil captured_params[:client_reference_id]
+  end
+
   test "marks invalid session discount while still allowing customer promotion codes" do
     @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
     Stripe::Coupon.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("No such coupon", nil))

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -81,17 +81,37 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
     assert_not_respond_to builder, :selected_address_id
   end
 
+  test "uses selected saved address as Stripe customer for logged-in checkout" do
+    user = users(:one)
+    address = addresses(:office)
+    user.update!(stripe_customer_id: "cus_saved_address")
+    user.expects(:sync_stripe_customer!).with(address: address).once
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    result = build_session_builder(user: user, address_id: address.id).create
+
+    assert_equal address.id, result.selected_address_id
+    assert_equal "cus_saved_address", captured_params[:customer]
+    assert_nil captured_params[:customer_email]
+  end
+
   private
 
   def build_session(discount_code: nil)
     build_session_builder(discount_code: discount_code).create
   end
 
-  def build_session_builder(discount_code: nil)
+  def build_session_builder(user: nil, address_id: nil, discount_code: nil)
     Checkout::SessionBuilder.new(
       cart: @cart,
-      user: nil,
-      address_id: nil,
+      user: user,
+      address_id: address_id,
       discount_code: discount_code,
       datafast_visitor_id: nil,
       datafast_session_id: nil,

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -70,12 +70,24 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
 
     assert result.invalid_discount?
     assert_equal true, captured_params[:allow_promotion_codes]
-    assert_nil captured_params[:metadata][:discount_code]
+    assert_not captured_params[:metadata].key?(:discount_code)
+  end
+
+  test "does not expose intermediate checkout state readers" do
+    builder = build_session_builder(discount_code: "WELCOME5")
+
+    assert_respond_to builder, :invalid_discount?
+    assert_not_respond_to builder, :invalid_discount_code
+    assert_not_respond_to builder, :selected_address_id
   end
 
   private
 
   def build_session(discount_code: nil)
+    build_session_builder(discount_code: discount_code).create
+  end
+
+  def build_session_builder(discount_code: nil)
     Checkout::SessionBuilder.new(
       cart: @cart,
       user: nil,
@@ -85,6 +97,6 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
       datafast_session_id: nil,
       success_url: @success_url,
       cancel_url: @cancel_url
-    ).create
+    )
   end
 end

--- a/test/services/checkout/stripe_tax_rate_provider_test.rb
+++ b/test/services/checkout/stripe_tax_rate_provider_test.rb
@@ -55,4 +55,13 @@ class Checkout::StripeTaxRateProviderTest < ActiveSupport::TestCase
     assert_equal existing_tax_rate, provider.tax_rate
     assert_equal existing_tax_rate, provider.tax_rate
   end
+
+  test "propagates Stripe API failures without caching a tax rate id" do
+    Stripe::TaxRate.expects(:list).raises(StripeErrors.api_connection_error)
+
+    assert_raises(Stripe::APIConnectionError) do
+      Checkout::StripeTaxRateProvider.new.tax_rate
+    end
+    assert_nil Rails.cache.read(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY)
+  end
 end

--- a/test/services/checkout/stripe_tax_rate_provider_test.rb
+++ b/test/services/checkout/stripe_tax_rate_provider_test.rb
@@ -3,12 +3,24 @@ require "test_helper"
 class Checkout::StripeTaxRateProviderTest < ActiveSupport::TestCase
   include StripeTestHelper
 
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.delete(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY)
+  end
+
+  teardown do
+    Rails.cache.delete(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY)
+    Rails.cache = @original_cache
+  end
+
   test "returns an existing active exclusive UK VAT tax rate" do
     existing_tax_rate = build_stripe_tax_rate(id: "txr_existing")
     Stripe::TaxRate.expects(:list).with(active: true, limit: 100).returns(build_stripe_list([ existing_tax_rate ]))
     Stripe::TaxRate.expects(:create).never
 
     assert_equal existing_tax_rate, Checkout::StripeTaxRateProvider.new.tax_rate
+    assert_equal "txr_existing", Rails.cache.read(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY)
   end
 
   test "creates UK VAT tax rate when none exists" do
@@ -24,6 +36,15 @@ class Checkout::StripeTaxRateProviderTest < ActiveSupport::TestCase
     }).returns(created_tax_rate)
 
     assert_equal created_tax_rate, Checkout::StripeTaxRateProvider.new.tax_rate
+    assert_equal "txr_created", Rails.cache.read(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY)
+  end
+
+  test "uses cached tax rate id without listing tax rates" do
+    Rails.cache.write(Checkout::StripeTaxRateProvider::UK_VAT_RATE_ID_CACHE_KEY, "txr_cached")
+    Stripe::TaxRate.expects(:list).never
+    Stripe::TaxRate.expects(:create).never
+
+    assert_equal "txr_cached", Checkout::StripeTaxRateProvider.new.tax_rate.id
   end
 
   test "memoizes tax rate for one provider instance" do

--- a/test/services/checkout/stripe_tax_rate_provider_test.rb
+++ b/test/services/checkout/stripe_tax_rate_provider_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Checkout::StripeTaxRateProviderTest < ActiveSupport::TestCase
+  include StripeTestHelper
+
+  test "returns an existing active exclusive UK VAT tax rate" do
+    existing_tax_rate = build_stripe_tax_rate(id: "txr_existing")
+    Stripe::TaxRate.expects(:list).with(active: true, limit: 100).returns(build_stripe_list([ existing_tax_rate ]))
+    Stripe::TaxRate.expects(:create).never
+
+    assert_equal existing_tax_rate, Checkout::StripeTaxRateProvider.new.tax_rate
+  end
+
+  test "creates UK VAT tax rate when none exists" do
+    created_tax_rate = build_stripe_tax_rate(id: "txr_created")
+    Stripe::TaxRate.expects(:list).with(active: true, limit: 100).returns(build_stripe_list([]))
+    Stripe::TaxRate.expects(:create).with({
+      display_name: "VAT",
+      percentage: 20,
+      country: "GB",
+      jurisdiction: "United Kingdom",
+      description: "Value Added Tax",
+      inclusive: false
+    }).returns(created_tax_rate)
+
+    assert_equal created_tax_rate, Checkout::StripeTaxRateProvider.new.tax_rate
+  end
+
+  test "memoizes tax rate for one provider instance" do
+    existing_tax_rate = build_stripe_tax_rate(id: "txr_existing")
+    provider = Checkout::StripeTaxRateProvider.new
+    Stripe::TaxRate.expects(:list).once.returns(build_stripe_list([ existing_tax_rate ]))
+
+    assert_equal existing_tax_rate, provider.tax_rate
+    assert_equal existing_tax_rate, provider.tax_rate
+  end
+end


### PR DESCRIPTION
## Summary
- Extract Stripe Checkout session construction into Checkout::SessionBuilder
- Extract paid session order creation into Checkout::OrderCreator
- Extract UK VAT tax-rate lookup into Checkout::StripeTaxRateProvider
- Add regression coverage for invalid discount cleanup when later Stripe session creation fails

## Tests
- bin/rails test test/controllers/checkouts_controller_test.rb
- RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec rubocop app/controllers/checkouts_controller.rb app/services/checkout/session_builder.rb app/services/checkout/order_creator.rb app/services/checkout/stripe_tax_rate_provider.rb test/controllers/checkouts_controller_test.rb