### PR TITLE
Derive product title size from dimensions

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -228,13 +228,32 @@ class Product < ApplicationRecord
     display_name
   end
 
-  # Generated title from product attributes
-  # Combines brand, size, colour, material, and name into a descriptive title
-  # Example: "Vegware 12oz White Paper Coffee Cups"
-  # Deduplicates when colour and material are identical (e.g., "Kraft Kraft" -> "Kraft")
+  # Generated title from product attributes.
+  # Combines brand, colour, material, and name into a descriptive title, then
+  # appends the size after a dash. The size token is the free-text size when
+  # present, otherwise a value derived from the dimension columns.
+  # Example: "Vegware White Paper Coffee Cups - 12oz"
+  # Deduplicates when colour and material are identical (e.g. "Kraft Kraft" -> "Kraft")
   def generated_title
-    parts = [ brand, size, colour, material, name ].compact_blank.uniq(&:downcase)
-    parts.join(" ")
+    base = [ brand, colour, material, name ].compact_blank.uniq(&:downcase).join(" ")
+    token = size.presence || derived_size
+    token.present? ? "#{base} - #{token}" : base
+  end
+
+  # Human-readable size token derived from the dimension columns, used by
+  # generated_title when the free-text size is blank. Prefers volume, then the
+  # present linear dimensions (LxWxH), then weight. Returns nil when no
+  # dimensional data exists. pac_size is a pack quantity, not a physical size, so
+  # it is intentionally excluded.
+  def derived_size
+    return "#{volume_in_ml}ml" if volume_in_ml.to_i.positive?
+
+    linear = [ length_in_mm, width_in_mm, height_in_mm ].select { |d| d.to_i.positive? }
+    return "#{linear.join(' x ')}mm" if linear.any?
+
+    return "#{weight_in_g}g" if weight_in_g.to_i.positive?
+
+    nil
   end
 
   META_TITLE_BENEFIT_PRIORITY = [ "Compostable", "Recyclable", "Biodegradable", "Plastic Free" ].freeze

--- a/db/migrate/20260528211126_add_supplier_sku_to_products.rb
+++ b/db/migrate/20260528211126_add_supplier_sku_to_products.rb
@@ -1,0 +1,6 @@
+class AddSupplierSkuToProducts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :products, :supplier_sku, :string
+    add_index :products, :supplier_sku
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_074026) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_211126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -372,6 +372,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_074026) do
     t.string "sku", null: false
     t.string "slug", limit: 255, null: false
     t.integer "stock_quantity", default: 0
+    t.string "supplier_sku"
     t.datetime "updated_at", null: false
     t.decimal "vat_rate", precision: 6, scale: 4
     t.integer "volume_in_ml"
@@ -388,6 +389,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_074026) do
     t.index ["product_type"], name: "index_products_on_product_type"
     t.index ["sample_eligible"], name: "index_products_on_sample_eligible"
     t.index ["slug"], name: "index_products_on_slug", unique: true
+    t.index ["supplier_sku"], name: "index_products_on_supplier_sku"
   end
 
   create_table "reorder_schedule_items", force: :cascade do |t|

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -720,8 +720,6 @@ class ProductTest < ActiveSupport::TestCase
     assert_equal "Bagasse Clamshell - 12oz", product.generated_title
   end
 
-  # Derived-size tests: when free-text size is blank, the size token is derived
-  # from the dimension columns and appended in parentheses.
   test "generated_title derives size from volume when free-text size blank" do
     product = products(:one)
     product.update_columns(

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -615,7 +615,7 @@ class ProductTest < ActiveSupport::TestCase
       name: "Coffee Cups"
     )
 
-    assert_equal "Vegware 8oz White Paper Coffee Cups", product.generated_title
+    assert_equal "Vegware White Paper Coffee Cups - 8oz", product.generated_title
   end
 
   test "generated_title omits blank attributes" do
@@ -654,7 +654,7 @@ class ProductTest < ActiveSupport::TestCase
       name: "Straws"
     )
 
-    assert_equal "6 x 200mm Natural Bamboo Pulp Straws", product.generated_title
+    assert_equal "Natural Bamboo Pulp Straws - 6 x 200mm", product.generated_title
   end
 
   test "generated_title skips empty strings" do
@@ -680,7 +680,7 @@ class ProductTest < ActiveSupport::TestCase
       name: "Pizza Boxes"
     )
 
-    assert_equal "16 inch / 406 x 406mm Kraft Pizza Boxes", product.generated_title
+    assert_equal "Kraft Pizza Boxes - 16 inch / 406 x 406mm", product.generated_title
   end
 
   test "generated_title deduplication is case-insensitive" do
@@ -717,7 +717,195 @@ class ProductTest < ActiveSupport::TestCase
       name: "Clamshell"
     )
 
-    assert_equal "12oz Bagasse Clamshell", product.generated_title
+    assert_equal "Bagasse Clamshell - 12oz", product.generated_title
+  end
+
+  # Derived-size tests: when free-text size is blank, the size token is derived
+  # from the dimension columns and appended in parentheses.
+  test "generated_title derives size from volume when free-text size blank" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: 650,
+      colour: "White",
+      material: "Paper",
+      name: "Deli Container"
+    )
+
+    assert_equal "White Paper Deli Container - 650ml", product.generated_title
+  end
+
+  test "generated_title prefers free-text size over derived size" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: "8oz",
+      volume_in_ml: 650,
+      colour: nil,
+      material: nil,
+      name: "Deli Container"
+    )
+
+    assert_equal "Deli Container - 8oz", product.generated_title
+  end
+
+  test "generated_title derives LxWxH from linear dimensions" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: 200,
+      width_in_mm: 200,
+      height_in_mm: 80,
+      colour: "Kraft",
+      material: "Kraft",
+      name: "Pizza Box"
+    )
+
+    assert_equal "Kraft Pizza Box - 200 x 200 x 80mm", product.generated_title
+  end
+
+  test "generated_title derives LxW when height absent" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: 200,
+      width_in_mm: 150,
+      height_in_mm: nil,
+      colour: nil,
+      material: nil,
+      name: "Tray"
+    )
+
+    assert_equal "Tray - 200 x 150mm", product.generated_title
+  end
+
+  test "generated_title derives single dimension when only width present" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: nil,
+      width_in_mm: 90,
+      height_in_mm: nil,
+      colour: nil,
+      material: nil,
+      name: "Lid"
+    )
+
+    assert_equal "Lid - 90mm", product.generated_title
+  end
+
+  test "generated_title falls back to weight when only weight present" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: nil,
+      width_in_mm: nil,
+      height_in_mm: nil,
+      weight_in_g: 500,
+      colour: nil,
+      material: nil,
+      name: "Napkin Pack"
+    )
+
+    assert_equal "Napkin Pack - 500g", product.generated_title
+  end
+
+  test "generated_title prefers volume over linear dimensions" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: 1000,
+      length_in_mm: 200,
+      width_in_mm: 200,
+      colour: nil,
+      material: nil,
+      name: "Tub"
+    )
+
+    assert_equal "Tub - 1000ml", product.generated_title
+  end
+
+  test "generated_title omits size token when size and all dimensions blank" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: nil,
+      width_in_mm: nil,
+      height_in_mm: nil,
+      weight_in_g: nil,
+      colour: "White",
+      material: nil,
+      name: "Coffee Cups"
+    )
+
+    assert_equal "White Coffee Cups", product.generated_title
+  end
+
+  test "generated_title ignores pac_size when deriving size" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: nil,
+      length_in_mm: nil,
+      width_in_mm: nil,
+      height_in_mm: nil,
+      weight_in_g: nil,
+      pac_size: 1000,
+      colour: nil,
+      material: nil,
+      name: "Mystery Item"
+    )
+
+    assert_equal "Mystery Item", product.generated_title
+  end
+
+  test "generated_title treats zero dimensions as absent" do
+    product = products(:one)
+    product.update_columns(
+      brand: nil,
+      size: nil,
+      volume_in_ml: 0,
+      width_in_mm: 0,
+      weight_in_g: 0,
+      colour: nil,
+      material: nil,
+      name: "Empty Dims"
+    )
+
+    assert_equal "Empty Dims", product.generated_title
+  end
+
+  test "derived_size returns volume token in ml" do
+    product = products(:one)
+    product.update_columns(volume_in_ml: 330)
+
+    assert_equal "330ml", product.derived_size
+  end
+
+  test "derived_size returns nil when no dimensional data" do
+    product = products(:one)
+    product.update_columns(
+      volume_in_ml: nil,
+      length_in_mm: nil,
+      width_in_mm: nil,
+      height_in_mm: nil,
+      weight_in_g: nil
+    )
+
+    assert_nil product.derived_size
   end
 
   # ==========================================================================
@@ -751,7 +939,7 @@ class ProductTest < ActiveSupport::TestCase
       brand: "Vegware", size: "12oz", colour: "Kraft", material: "Paper",
       name: "Hot Cup", certifications: "Compostable"
     )
-    assert_equal "Vegware 12oz Kraft Paper Hot Cup, Compostable", product.generated_meta_title
+    assert_equal "Vegware Kraft Paper Hot Cup - 12oz, Compostable", product.generated_meta_title
   end
 
   test "generated_meta_title appends recyclable when compostable is absent" do
@@ -760,7 +948,7 @@ class ProductTest < ActiveSupport::TestCase
       brand: nil, size: "12oz", colour: "Clear", material: "rPET",
       name: "Smoothie Cup", certifications: "Recyclable, Food Safe"
     )
-    assert_equal "12oz Clear rPET Smoothie Cup, Recyclable", product.generated_meta_title
+    assert_equal "Clear rPET Smoothie Cup - 12oz, Recyclable", product.generated_meta_title
   end
 
   test "generated_meta_title prioritises compostable over recyclable" do
@@ -796,7 +984,7 @@ class ProductTest < ActiveSupport::TestCase
       brand: nil, size: "160mm", colour: nil, material: "Wood",
       name: "Compostable Cutlery Kit", certifications: "Compostable"
     )
-    assert_equal "160mm Wood Compostable Cutlery Kit", product.generated_meta_title
+    assert_equal "Wood Compostable Cutlery Kit - 160mm", product.generated_meta_title
   end
 
   test "generated_meta_title drops suffix when combined length exceeds 60 chars" do
@@ -806,8 +994,8 @@ class ProductTest < ActiveSupport::TestCase
       material: "Lined", name: "Compostable Takeaway Cup with Lid",
       certifications: "Recyclable"
     )
-    # Base: "12oz Kraft Aqueous Lined Compostable Takeaway Cup with Lid" = 58 chars
-    # With suffix: ", Recyclable" makes it 70 chars -> should drop suffix
+    # Base: "Kraft Aqueous Lined Compostable Takeaway Cup with Lid - 12oz" = 60 chars
+    # With suffix: ", Recyclable" pushes it past 60 -> should drop suffix
     assert_equal product.generated_title, product.generated_meta_title
   end
 
@@ -833,7 +1021,7 @@ class ProductTest < ActiveSupport::TestCase
       brand: nil, size: "8oz", colour: nil, material: "Paper",
       name: "Cold Cup", pac_size: 500, description_short: nil
     )
-    assert_equal "8oz Paper Cold Cup. Case of 500, free UK delivery over £100.",
+    assert_equal "Paper Cold Cup - 8oz. Case of 500, free UK delivery over £100.",
                  product.generated_meta_description
   end
 


### PR DESCRIPTION
## Summary

`Product#generated_title` built the public-facing title from the free-text `size` column, which is `nil` for most variant products. Distinct-size variants (e.g. 8/12/16/24/32oz deli containers) collapsed to identical titles, leaking duplicates into SEO `<title>` tags (via `generated_meta_title`) and `order_item.product_name` snapshots.

Now the size token is the free-text `size` when present, otherwise a value **derived from the dimension columns** (volume, then `L x W x H`, then weight), appended after a dash:

- `Vegware PLA Hinged Lid Deli Container - 105 x 122 x 50mm`
- `Vegware Kraft Flat Bag - 305 x 305mm`
- `Vegware White Paper Coffee Cups - 8oz` (free-text size still wins)

`pac_size` is intentionally excluded (it is a pack quantity, not a physical size).

## Production impact (read-only dry-run via kamal)

Duplicate `generated_title` groups drop from **22 (61 products)** to **8 (16 products)**. The 14 dimensioned variant groups all resolve; the remaining 8 have no dimensional data (size lives only in the SKU/name) and need a separate data backfill.

## Commits

1. **Derive product title size from dimensions** — the `generated_title` / `derived_size` change plus tests.
2. **Add supplier_sku column to products** — unrelated migration + schema bump, kept as its own commit.

## Testing

TDD (red-green-refactor). Full suite green: 2248 runs, 0 failures, 0 errors. Updated the existing `generated_title` / `generated_meta_*` assertions and added coverage for volume/linear/weight derivation, the free-text-wins rule, `pac_size` exclusion, and zero-as-absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)