### PR TITLE
Remove 'another email when it ships' line from order confirmation email

### DIFF
--- a/app/views/order_mailer/confirmation_email.html.erb
+++ b/app/views/order_mailer/confirmation_email.html.erb
@@ -65,8 +65,7 @@
 
   <tr>
     <td align="center" style="padding: 40px 30px;">
-      <p style="color: #6b7280; font-size: 14px;">We'll notify you when your order ships.</p>
-      <p style="color: #6b7280; font-size: 14px; margin-top: 5px;">Thanks for choosing Afida. We appreciate it.</p>
+      <p style="color: #6b7280; font-size: 14px;">Thanks for choosing Afida. We appreciate it.</p>
     </td>
   </tr>
 </table>

--- a/app/views/order_mailer/confirmation_email.html.erb
+++ b/app/views/order_mailer/confirmation_email.html.erb
@@ -6,7 +6,7 @@
         <strong>Thanks, <%= @order.shipping_name %>.</strong>
         <br>
         <br>
-        Your order is in and we're getting it packed. You'll get another email when it ships.
+        Your order is in and we're getting it packed.
         <br>
         <br>
         Your order number is <strong style="color: #111827;">#<%= @order.order_number %></strong>.

--- a/app/views/order_mailer/confirmation_email.text.erb
+++ b/app/views/order_mailer/confirmation_email.text.erb
@@ -15,8 +15,6 @@ Shipping: <%= number_to_currency(@order.shipping_amount, unit: "£") %>
 VAT (20%): <%= number_to_currency(@order.vat_amount, unit: "£") %>
 Total: <%= number_to_currency(@order.total_amount, unit: "£") %>
 
-We will notify you again when your order has shipped.
-
 You can view your order details here: <%= order_url(@order, token: @order.signed_access_token) %>
 
 Thanks for shopping with us! 

--- a/test/mailers/order_mailer_test.rb
+++ b/test/mailers/order_mailer_test.rb
@@ -39,6 +39,15 @@ class OrderMailerTest < ActionMailer::TestCase
     assert_match @order.shipping_name, email.body.encoded
   end
 
+  test "confirmation_email does not promise a shipping-notification email" do
+    email = OrderMailer.with(order: @order).confirmation_email
+    body = email.body.encoded
+
+    assert_no_match(/another email when it ships/i, body)
+    assert_no_match(/notify you when your order ships/i, body)
+    assert_no_match(/notify you again when your order has shipped/i, body)
+  end
+
   test "confirmation_email has both HTML and text parts" do
     email = OrderMailer.with(order: @order).confirmation_email
 


### PR DESCRIPTION
Removes the shipping-notification promise from the order confirmation email.

Originally this targeted just the intro line "You'll get another email when it ships." in the HTML email. PR review correctly pointed out the same promise survived in two more places, so the email still made the promise. All three are now removed:

- HTML intro: "You'll get another email when it ships." (removed)
- HTML footer: "We'll notify you when your order ships." (removed)
- Plain-text body: "We will notify you again when your order has shipped." (removed)

(Correcting the earlier description: the plain-text template *did* carry an equivalent promise, just worded differently.)

Added a mailer test asserting none of the three phrasings appear in the email body, so the copy can't quietly return.

Note: the email template's pre-existing inline styles and font-weight values (flagged by review) are intentionally left out of scope for this focused copy change; this PR adds no new inline styles or weights.

Separate from #190 (delivery-promise work), branched off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)