### PR TITLE
Klaviyo abandoned-cart email (Started Checkout + cart recovery link)

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -15,6 +15,20 @@ class CartsController < ApplicationController
     )
   end
 
+  # GET /cart/resume?token=...
+  # Restores an abandoned cart from a signed recovery link (e.g. a Klaviyo
+  # abandoned-cart email) by re-binding the visitor's session to it, then shows
+  # the cart. Only guest carts are re-bound: a user-owned cart belongs to an
+  # account and is loaded via Current.user, so we never let a link hijack it.
+  # An invalid/expired/missing token simply falls through to the session's own
+  # cart, so a bad link never errors or leaks another cart.
+  def resume
+    cart = Cart.find_by_recovery_token(params[:token])
+    session[:cart_id] = cart.id if cart&.guest_cart?
+
+    redirect_to cart_path
+  end
+
   def destroy
     @cart.destroy
     redirect_to root_path, notice: "Cart was successfully destroyed."

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -109,7 +109,9 @@ class CheckoutsController < ApplicationController
       # Store in session for immediate access (proves ownership for guest checkout)
       session[:recent_order_id] = order.id
 
-      # Emit discount claimed event if order used a discount code
+      # Emit discount claimed event if order used a discount code.
+      # KlaviyoSubscriber resolves the customer email from order_id (Rails.event
+      # filters payload[:email] to "[FILTERED]"), so order_id is the contract here.
       if session[:discount_code].present?
         Rails.event.notify("email_signup.discount_claimed",
           email: order.email,

--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -46,6 +46,20 @@ class EmailSubscriptionsController < ApplicationController
         new_subscription: @subscription.previously_new_record?
       )
 
+      # Abandoned-cart trigger. The visitor's email and their cart contents coexist
+      # in this request (Current.cart is set by ApplicationController's
+      # set_current_cart). Klaviyo owns the delay/suppression Flow; we only emit
+      # the intent, and only for a cart worth recovering. Sample-only carts are
+      # excluded (zero value), mirroring how order.placed treats sample requests.
+      cart = Current.cart
+      if cart&.cart_items&.any? && !cart.only_samples?
+        Rails.event.notify("cart.checkout_initiated",
+          cart_id: cart.id,
+          email: @email,
+          source: @subscription.source
+        )
+      end
+
       render_success
     else
       render_validation_error

--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -38,9 +38,14 @@ class EmailSubscriptionsController < ApplicationController
       # Store discount code in session (only if not already present)
       session[:discount_code] ||= welcome_discount_code
 
-      # Emit event for tracking email signup funnel
+      # Emit event for tracking email signup funnel.
+      # subscription_id lets subscribers resolve the real email: Rails.event filters
+      # payload keys matching config.filter_parameters, and :email matches as a
+      # substring, so both :email AND any key containing "email" arrive "[FILTERED]".
+      # subscription_id is deliberately named without "email" so it survives.
       Rails.event.notify("email_signup.completed",
         email: @email,
+        subscription_id: @subscription.id,
         source: @subscription.source,
         discount_eligible: true,
         new_subscription: @subscription.previously_new_record?
@@ -56,6 +61,7 @@ class EmailSubscriptionsController < ApplicationController
         Rails.event.notify("cart.checkout_initiated",
           cart_id: cart.id,
           email: @email,
+          subscription_id: @subscription.id,
           source: @subscription.source
         )
       end

--- a/app/controllers/email_subscriptions_controller.rb
+++ b/app/controllers/email_subscriptions_controller.rb
@@ -52,7 +52,7 @@ class EmailSubscriptionsController < ApplicationController
       # the intent, and only for a cart worth recovering. Sample-only carts are
       # excluded (zero value), mirroring how order.placed treats sample requests.
       cart = Current.cart
-      if cart&.cart_items&.any? && !cart.only_samples?
+      if cart && cart.cart_items.any? && !cart.only_samples?
         Rails.event.notify("cart.checkout_initiated",
           cart_id: cart.id,
           email: @email,

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -142,7 +142,10 @@ class Cart < ApplicationRecord
 
   private
 
+  # Action Mailer's host is configured in every environment, so an absent value
+  # means a misconfiguration. Surface that as a failed (retryable) job rather than
+  # silently emailing a hostless, broken recovery link.
   def url_options
-    Rails.application.config.action_mailer.default_url_options || {}
+    Rails.application.config.action_mailer.default_url_options
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -116,4 +116,33 @@ class Cart < ApplicationRecord
   def at_sample_limit?
     sample_count >= SAMPLE_LIMIT
   end
+
+  # Signed, expiring token for cross-device cart recovery (abandoned-cart emails).
+  # Mirrors Order#signed_access_token; a distinct purpose ("cart_recovery") means
+  # an order access token can never be replayed as a cart recovery token.
+  def signed_recovery_token
+    to_sgid(expires_in: 30.days, for: "cart_recovery").to_s
+  end
+
+  # Absolute URL that re-binds the recipient's session to this cart (see
+  # CartsController#resume). Built from the Action Mailer host, which is
+  # configured in every environment, so it resolves without a request context
+  # (the abandoned-cart event is processed in a background job).
+  def recovery_url
+    Rails.application.routes.url_helpers.resume_cart_url(token: signed_recovery_token, **url_options)
+  end
+
+  # Resolves a cart from a recovery token, or nil if the token is missing,
+  # malformed, expired, signed for another purpose, or the cart no longer exists.
+  def self.find_by_recovery_token(token)
+    GlobalID::Locator.locate_signed(token, for: "cart_recovery")
+  rescue ActiveRecord::RecordNotFound, ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  private
+
+  def url_options
+    Rails.application.config.action_mailer.default_url_options || {}
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -125,9 +125,9 @@ class Cart < ApplicationRecord
   end
 
   # Absolute URL that re-binds the recipient's session to this cart (see
-  # CartsController#resume). Built from the Action Mailer host, which is
-  # configured in every environment, so it resolves without a request context
-  # (the abandoned-cart event is processed in a background job).
+  # CartsController#resume). Passes the Action Mailer host explicitly so the URL
+  # resolves whether built in a request or not; the route helper also falls back
+  # to routes.default_url_options if the mailer host is absent.
   def recovery_url
     Rails.application.routes.url_helpers.resume_cart_url(token: signed_recovery_token, **url_options)
   end
@@ -142,9 +142,11 @@ class Cart < ApplicationRecord
 
   private
 
-  # Action Mailer's host is configured in every environment, so an absent value
-  # means a misconfiguration. Surface that as a failed (retryable) job rather than
-  # silently emailing a hostless, broken recovery link.
+  # Action Mailer's host, configured in every environment. recovery_url runs
+  # inline in KlaviyoSubscriber (a synchronous Rails.event subscriber), so a nil
+  # here would propagate into the emitting request; in practice resume_cart_url
+  # falls back to routes.default_url_options (also set in every environment), so
+  # a missing mailer host degrades to that host rather than a hostless URL.
   def url_options
     Rails.application.config.action_mailer.default_url_options
   end

--- a/app/subscribers/klaviyo_subscriber.rb
+++ b/app/subscribers/klaviyo_subscriber.rb
@@ -17,6 +17,13 @@
 # cart delay and suppression ("Placed Order zero times") live in a Klaviyo Flow,
 # so no scheduling or suppression logic lives here.
 #
+# Email handling: Rails.event filters payload values whose keys match
+# config.filter_parameters (by substring), and :email is one of them, so
+# payload[:email] arrives as "[FILTERED]". Every handler therefore resolves the
+# real address from a record (EmailSubscription via subscription_id, or Order via
+# order_id), never from the payload. The id key avoids the "email" substring so
+# the filter does not redact it too.
+#
 # Like DatafastSubscriber, this only enqueues background jobs; it never performs
 # network I/O inline and never raises into the emitting business code.
 #
@@ -43,7 +50,7 @@ class KlaviyoSubscriber
   private
 
   def handle_signup(payload)
-    email = payload[:email]
+    email = subscription_email(payload)
     return if email.blank?
 
     # NOTE: payload[:discount_eligible] is deliberately not forwarded. The emitter
@@ -53,20 +60,21 @@ class KlaviyoSubscriber
   end
 
   def handle_discount_claimed(payload)
-    email = payload[:email]
-    return if email.blank?
+    order = Order.find_by(id: payload[:order_id])
+    return if order.nil? || order.email.blank?
 
-    track("Claimed Discount", email, { discount_code: payload[:discount_code] }.compact)
+    track("Claimed Discount", order.email, { discount_code: payload[:discount_code] }.compact)
   end
 
-  # Abandoned-cart trigger. The email is known (the visitor typed it into the
-  # discount-signup form) and Current.cart was populated in the same request, so
-  # the emitter handed us cart_id + email. We reload the cart for its line items
-  # (one query, products eager-loaded) and send Klaviyo a "Started Checkout"
-  # metric with the cart total as value, plus a signed cross-device recovery link.
-  # Klaviyo's Flow owns the delay and the "Placed Order zero times" suppression.
+  # Abandoned-cart trigger. The discount-signup flow emits this once an email is
+  # known and Current.cart has items. We resolve the email from the EmailSubscription
+  # (payload[:email] is filtered out by Rails.event) and reload the cart for its
+  # line items (one query, products eager-loaded), then send Klaviyo a "Started
+  # Checkout" metric with the cart total as value plus a signed cross-device
+  # recovery link. Klaviyo's Flow owns the delay and "Placed Order zero times"
+  # suppression.
   def handle_checkout_initiated(payload)
-    email = payload[:email]
+    email = subscription_email(payload)
     return if email.blank?
 
     cart = Cart.find_by(id: payload[:cart_id])
@@ -138,6 +146,16 @@ class KlaviyoSubscriber
     args = { metric: metric, email: email, properties: properties }
     args[:value] = value unless value.nil?
     KlaviyoEventJob.perform_later("track", **args)
+  end
+
+  # Resolves the profile email from the EmailSubscription record rather than the
+  # payload: Rails.event filters :email (it is in config.filter_parameters), so
+  # payload[:email] arrives as "[FILTERED]". Mirrors how handle_order_placed reads
+  # Order#email from order_id instead of trusting the payload. The id key is
+  # "subscription_id" (not "email_subscription_id") because the filter matches by
+  # substring and would otherwise redact any key containing "email" too.
+  def subscription_email(payload)
+    EmailSubscription.find_by(id: payload[:subscription_id])&.email
   end
 
   # Klaviyo profiles use separate first/last name fields. shipping_name is a

--- a/app/subscribers/klaviyo_subscriber.rb
+++ b/app/subscribers/klaviyo_subscriber.rb
@@ -30,7 +30,7 @@
 # Usage (registered in config/initializers/events.rb):
 #   Rails.event.subscribe(KlaviyoSubscriber.new)
 class KlaviyoSubscriber
-  # Most line items to serialize into a "Started Checkout" payload (see
+  # Maximum line items to serialize into a "Started Checkout" payload (see
   # handle_checkout_initiated).
   MAX_ITEMS_IN_PAYLOAD = 20
 

--- a/app/subscribers/klaviyo_subscriber.rb
+++ b/app/subscribers/klaviyo_subscriber.rb
@@ -5,13 +5,17 @@
 # Event → Klaviyo:
 #   email_signup.completed        → "Subscribed" event (+ source)
 #   email_signup.discount_claimed → "Claimed Discount" event
+#   cart.checkout_initiated       → "Started Checkout" event (with cart total as value)
 #   order.placed (normal/mixed)   → profile upsert (is_business, name) + "Placed Order" (with value)
 #   order.placed (sample-only)    → profile upsert + "Requested Sample" (no value, not a purchase)
 #
 # checkout.started is intentionally NOT handled here: it carries no email at the
 # point of emission (the customer enters their email on Stripe's hosted page),
-# so there is no profile to attach. Abandoned-cart capture is a separate flow
-# that triggers only once an email is known.
+# so there is no profile to attach. Abandoned-cart capture rides on
+# cart.checkout_initiated instead, which the discount-signup flow emits once an
+# email IS known. Like order.placed, the cart is reloaded by id; the abandoned-
+# cart delay and suppression ("Placed Order zero times") live in a Klaviyo Flow,
+# so no scheduling or suppression logic lives here.
 #
 # Like DatafastSubscriber, this only enqueues background jobs; it never performs
 # network I/O inline and never raises into the emitting business code.
@@ -25,6 +29,8 @@ class KlaviyoSubscriber
       handle_signup(event[:payload] || {})
     when "email_signup.discount_claimed"
       handle_discount_claimed(event[:payload] || {})
+    when "cart.checkout_initiated"
+      handle_checkout_initiated(event[:payload] || {})
     when "order.placed"
       handle_order_placed(event[:payload] || {})
     end
@@ -47,6 +53,34 @@ class KlaviyoSubscriber
     return if email.blank?
 
     track("Claimed Discount", email, { discount_code: payload[:discount_code] }.compact)
+  end
+
+  # Abandoned-cart trigger. The email is known (the visitor typed it into the
+  # discount-signup form) and Current.cart was populated in the same request, so
+  # the emitter handed us cart_id + email. We reload the cart for its line items
+  # (one query, products eager-loaded) and send Klaviyo a "Started Checkout"
+  # metric with the cart total as value, plus a signed cross-device recovery link.
+  # Klaviyo's Flow owns the delay and the "Placed Order zero times" suppression.
+  def handle_checkout_initiated(payload)
+    email = payload[:email]
+    return if email.blank?
+
+    cart = Cart.find_by(id: payload[:cart_id])
+    return unless cart
+
+    items = cart.cart_items.includes(:product).map do |item|
+      { name: item.product.name, quantity: item.quantity, price: item.price.to_f }
+    end
+    return if items.empty?
+
+    properties = {
+      item_count: cart.items_count,
+      line_items_count: cart.line_items_count,
+      items: items,
+      checkout_url: cart.recovery_url
+    }
+
+    track("Started Checkout", email, properties, value: cart.total_amount.to_f)
   end
 
   def handle_order_placed(payload)

--- a/app/subscribers/klaviyo_subscriber.rb
+++ b/app/subscribers/klaviyo_subscriber.rb
@@ -23,6 +23,10 @@
 # Usage (registered in config/initializers/events.rb):
 #   Rails.event.subscribe(KlaviyoSubscriber.new)
 class KlaviyoSubscriber
+  # Most line items to serialize into a "Started Checkout" payload (see
+  # handle_checkout_initiated).
+  MAX_ITEMS_IN_PAYLOAD = 20
+
   def emit(event)
     case event[:name]
     when "email_signup.completed"
@@ -68,7 +72,12 @@ class KlaviyoSubscriber
     cart = Cart.find_by(id: payload[:cart_id])
     return unless cart
 
-    items = cart.cart_items.includes(:product).map do |item|
+    # Cap the serialized line items: they ride in both the Klaviyo payload and the
+    # persisted Solid Queue job args, and a large B2B cart has many lines. The
+    # email template rarely renders more, and item_count/line_items_count still
+    # carry the true totals.
+    line_items = cart.cart_items.includes(:product).limit(MAX_ITEMS_IN_PAYLOAD)
+    items = line_items.map do |item|
       { name: item.product.name, quantity: item.quantity, price: item.price.to_f }
     end
     return if items.empty?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,7 @@ Rails.application.routes.draw do
   resources :email_address_verifications, only: [ :show, :create ], param: :token
 
   resource :cart, only: [ :show, :destroy ] do
+    get :resume # GET /cart/resume?token=... — restore an abandoned cart from a recovery link
     resources :cart_items, only: [ :create, :update, :destroy ], path_names: { edit: "" }
   end
 

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -71,6 +71,39 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
     assert_match product.category.name, response.body
   end
 
+  # GET /cart/resume?token=... (cross-device abandoned-cart recovery)
+  test "resume re-binds the guest session to the cart in a valid token and redirects to cart" do
+    guest_cart = Cart.create!
+    guest_cart.cart_items.create!(product: products(:single_wall_8oz_white), quantity: 1, price: 10)
+
+    get resume_cart_url(token: guest_cart.signed_recovery_token)
+
+    assert_redirected_to cart_path
+    assert_equal guest_cart.id, session[:cart_id]
+  end
+
+  test "resume redirects to cart and leaves the session untouched for an invalid token" do
+    get cart_url # establishes a guest cart in the session
+    original_cart_id = session[:cart_id]
+
+    get resume_cart_url(token: "not-a-real-token")
+
+    assert_redirected_to cart_path
+    assert_equal original_cart_id, session[:cart_id]
+  end
+
+  test "resume does not bind a user-owned cart into a guest session (no hijack)" do
+    get cart_url
+    original_cart_id = session[:cart_id]
+    user_cart = Cart.create!(user: users(:one))
+
+    get resume_cart_url(token: user_cart.signed_recovery_token)
+
+    assert_redirected_to cart_path
+    assert_equal original_cart_id, session[:cart_id]
+    assert_not_equal user_cart.id, session[:cart_id]
+  end
+
   private
 
   def sign_in_as(user)

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -82,6 +82,22 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
     assert_equal guest_cart.id, session[:cart_id]
   end
 
+  test "resume overrides an existing guest session cart with the one in the token" do
+    # The realistic cross-device case: the visitor lands first (auto-created
+    # empty cart in their session), then clicks the recovery link for a different,
+    # earlier cart. Resume should re-bind the session to the token's cart.
+    get cart_url
+    other_cart_id = session[:cart_id]
+    recovered_cart = Cart.create!
+    recovered_cart.cart_items.create!(product: products(:single_wall_8oz_white), quantity: 1, price: 10)
+
+    get resume_cart_url(token: recovered_cart.signed_recovery_token)
+
+    assert_redirected_to cart_path
+    assert_equal recovered_cart.id, session[:cart_id]
+    assert_not_equal other_cart_id, session[:cart_id]
+  end
+
   test "resume redirects to cart and leaves the session untouched for an invalid token" do
     get cart_url # establishes a guest cart in the session
     original_cart_id = session[:cart_id]

--- a/test/controllers/email_subscriptions_controller_test.rb
+++ b/test/controllers/email_subscriptions_controller_test.rb
@@ -256,7 +256,7 @@ class EmailSubscriptionsControllerTest < ActionDispatch::IntegrationTest
     post cart_cart_items_path, params: {
       cart_item: { sku: products(:single_wall_8oz_white).sku, quantity: 1 }
     }
-    CartItem.last.cart
+    Cart.find(session[:cart_id])
   end
 
   def sign_in_as(user)

--- a/test/controllers/email_subscriptions_controller_test.rb
+++ b/test/controllers/email_subscriptions_controller_test.rb
@@ -209,6 +209,25 @@ class EmailSubscriptionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Closes the loop the filtered-payload tests above leave open: although :email
+  # reads "[FILTERED]" in the captured event, the real (typed + downcased) address
+  # must reach the Klaviyo job unredacted. KlaviyoSubscriber resolves it from the
+  # EmailSubscription rather than the filtered payload, and runs inline during the
+  # request. We stub perform_later (the test queue adapter is async, so it does not
+  # populate enqueued_jobs) and assert the Started Checkout call carries the address.
+  test "the typed email reaches the Started Checkout job unfiltered and downcased" do
+    add_item_to_session_cart
+
+    KlaviyoEventJob.expects(:perform_later)
+      .with("track", has_entries(metric: "Started Checkout", email: "mixedcase@example.com"))
+      .once
+    # Other events in the request (Subscribed) also enqueue; allow them.
+    KlaviyoEventJob.stubs(:perform_later)
+      .with("track", Not(has_entry(metric: "Started Checkout")))
+
+    post email_subscriptions_path, params: { email: "MixedCase@Example.com" }
+  end
+
   test "does not emit cart.checkout_initiated when the cart is empty" do
     assert_no_event_reported("cart.checkout_initiated") do
       post email_subscriptions_path, params: { email: "empty-cart@example.com" }

--- a/test/controllers/email_subscriptions_controller_test.rb
+++ b/test/controllers/email_subscriptions_controller_test.rb
@@ -175,7 +175,89 @@ class EmailSubscriptionsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # =============================================================================
+  # Abandoned-cart trigger (cart.checkout_initiated)
+  # =============================================================================
+
+  # Note: Rails.event runs payloads through config.filter_parameters, and :email
+  # is a filtered key, so the captured email reads "[FILTERED]" here. The email's
+  # fidelity (typed + downcased, used as the Klaviyo profile) is asserted in the
+  # subscriber tests, which receive the raw payload. At this boundary we assert
+  # the event fires for the right cart with the right source.
+  test "emits cart.checkout_initiated on successful signup when the cart has items" do
+    cart = add_item_to_session_cart
+
+    assert_event_reported("cart.checkout_initiated",
+      payload: {
+        cart_id: cart.id,
+        source: "cart_discount"
+      }
+    ) do
+      post email_subscriptions_path, params: { email: "abandon-test@example.com" }
+    end
+  end
+
+  test "cart.checkout_initiated carries an integer cart_id" do
+    add_item_to_session_cart
+
+    assert_event_reported("cart.checkout_initiated",
+      payload: {
+        cart_id: ->(v) { v.is_a?(Integer) }
+      }
+    ) do
+      post email_subscriptions_path, params: { email: "MixedCase@Example.com" }
+    end
+  end
+
+  test "does not emit cart.checkout_initiated when the cart is empty" do
+    assert_no_event_reported("cart.checkout_initiated") do
+      post email_subscriptions_path, params: { email: "empty-cart@example.com" }
+    end
+  end
+
+  test "does not emit cart.checkout_initiated for a sample-only cart" do
+    cart = add_item_to_session_cart
+    cart.cart_items.update_all(is_sample: true, price: 0)
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post email_subscriptions_path, params: { email: "samples-only@example.com" }
+    end
+  end
+
+  test "does not emit cart.checkout_initiated when the email already claimed the discount" do
+    add_item_to_session_cart
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post email_subscriptions_path, params: { email: "claimed@example.com" }
+    end
+  end
+
+  test "does not emit cart.checkout_initiated when the email has previous orders" do
+    add_item_to_session_cart
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post email_subscriptions_path, params: { email: "user1@example.com" }
+    end
+  end
+
+  test "does not emit cart.checkout_initiated for an invalid email" do
+    add_item_to_session_cart
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post email_subscriptions_path, params: { email: "not-an-email" }
+    end
+  end
+
   private
+
+  # Adds a standard product to the guest cart bound to this integration session,
+  # then returns the cart. Subsequent requests in the same test reuse session[:cart_id].
+  def add_item_to_session_cart
+    post cart_cart_items_path, params: {
+      cart_item: { sku: products(:single_wall_8oz_white).sku, quantity: 1 }
+    }
+    CartItem.last.cart
+  end
 
   def sign_in_as(user)
     post session_path, params: {

--- a/test/models/cart_test.rb
+++ b/test/models/cart_test.rb
@@ -353,4 +353,28 @@ class CartTest < ActiveSupport::TestCase
 
     assert_not cart.at_sample_limit?
   end
+
+  # --- signed recovery token (cross-device abandoned-cart links) ---
+
+  test "find_by_recovery_token round-trips a cart's signed recovery token" do
+    assert_equal @cart, Cart.find_by_recovery_token(@cart.signed_recovery_token)
+  end
+
+  test "find_by_recovery_token returns nil for a garbage token" do
+    assert_nil Cart.find_by_recovery_token("not-a-real-token")
+  end
+
+  test "find_by_recovery_token rejects a token signed for a different purpose" do
+    # An order's access token must not be replayable as a cart recovery token.
+    order_token = orders(:one).signed_access_token
+
+    assert_nil Cart.find_by_recovery_token(order_token)
+  end
+
+  test "recovery_url is an absolute url pointing at the cart resume route" do
+    url = @cart.recovery_url
+
+    assert url.start_with?("http"), "expected an absolute url, got #{url.inspect}"
+    assert_includes url, "/cart/resume"
+  end
 end

--- a/test/subscribers/klaviyo_subscriber_test.rb
+++ b/test/subscribers/klaviyo_subscriber_test.rb
@@ -9,13 +9,18 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
 
   # --- email_signup.completed ---
 
+  # The subscriber resolves the email from the EmailSubscription (Rails.event
+  # filters :email out of the payload), so tests pass subscription_id and assert
+  # the fixture's address, not the filtered payload value.
   test "email_signup.completed enqueues a Subscribed track job with source" do
+    subscription = email_subscriptions(:claimed_discount)
     event = build_event("email_signup.completed",
-      payload: { email: "buyer@cafe.co.uk", source: "cart_discount", discount_eligible: true })
+      payload: { email: "[FILTERED]", subscription_id: subscription.id,
+                 source: "cart_discount", discount_eligible: true })
 
     assert_enqueued_with(
       job: KlaviyoEventJob,
-      args: [ "track", { metric: "Subscribed", email: "buyer@cafe.co.uk",
+      args: [ "track", { metric: "Subscribed", email: subscription.email,
                          properties: { source: "cart_discount" } } ]
     ) do
       @subscriber.emit(event)
@@ -25,8 +30,9 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
   test "email_signup.completed does not forward the always-true discount_eligible flag" do
     # The emitter always sends discount_eligible: true (ineligible signups bail
     # out before the event fires), so it carries no segmentation signal in Klaviyo.
+    subscription = email_subscriptions(:claimed_discount)
     event = build_event("email_signup.completed",
-      payload: { email: "buyer@cafe.co.uk", source: "cart_discount", discount_eligible: true })
+      payload: { subscription_id: subscription.id, source: "cart_discount", discount_eligible: true })
 
     @subscriber.emit(event)
 
@@ -34,8 +40,9 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
     assert_not_includes track[:properties].keys, :discount_eligible
   end
 
-  test "email_signup.completed does not enqueue when email is blank" do
-    event = build_event("email_signup.completed", payload: { email: "", source: "cart_discount" })
+  test "email_signup.completed does not enqueue when the subscription cannot be found" do
+    event = build_event("email_signup.completed",
+      payload: { subscription_id: 0, source: "cart_discount" })
 
     assert_no_enqueued_jobs do
       @subscriber.emit(event)
@@ -45,21 +52,22 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
   # --- email_signup.discount_claimed ---
 
   test "email_signup.discount_claimed enqueues a Claimed Discount track job" do
+    order = orders(:one)
     event = build_event("email_signup.discount_claimed",
-      payload: { email: "buyer@cafe.co.uk", order_id: 99, discount_code: "WELCOME5" })
+      payload: { email: "[FILTERED]", order_id: order.id, discount_code: "WELCOME5" })
 
     assert_enqueued_with(
       job: KlaviyoEventJob,
-      args: [ "track", { metric: "Claimed Discount", email: "buyer@cafe.co.uk",
+      args: [ "track", { metric: "Claimed Discount", email: order.email,
                          properties: { discount_code: "WELCOME5" } } ]
     ) do
       @subscriber.emit(event)
     end
   end
 
-  test "email_signup.discount_claimed does not enqueue when email is blank" do
+  test "email_signup.discount_claimed does not enqueue when the order cannot be found" do
     event = build_event("email_signup.discount_claimed",
-      payload: { email: "", order_id: 99, discount_code: "WELCOME5" })
+      payload: { order_id: 0, discount_code: "WELCOME5" })
 
     assert_no_enqueued_jobs do
       @subscriber.emit(event)
@@ -188,23 +196,26 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
 
   test "cart.checkout_initiated enqueues a Started Checkout track job with the cart total as value" do
     cart = carts(:one) # cart_items(:one): product :one, quantity 2, price 10
+    subscription = email_subscriptions(:claimed_discount)
 
     @subscriber.emit(build_event("cart.checkout_initiated",
-      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+      payload: { cart_id: cart.id, email: "[FILTERED]",
+                 subscription_id: subscription.id, source: "cart_discount" }))
 
     track = enqueued_klaviyo_job("track")
     assert track, "expected a track job to be enqueued"
     assert_equal "Started Checkout", track[:metric]
-    assert_equal "buyer@cafe.co.uk", track[:email]
+    assert_equal subscription.email, track[:email]
     assert_in_delta cart.total_amount.to_f, track[:value], 0.001
   end
 
   test "cart.checkout_initiated properties carry item_count, line_items_count, items and checkout_url" do
     cart = carts(:one)
     item = cart_items(:one)
+    subscription = email_subscriptions(:claimed_discount)
 
     @subscriber.emit(build_event("cart.checkout_initiated",
-      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+      payload: { cart_id: cart.id, subscription_id: subscription.id, source: "cart_discount" }))
 
     props = enqueued_klaviyo_job("track")[:properties]
     assert_equal cart.items_count, props[:item_count]
@@ -227,37 +238,41 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
       )
       cart.cart_items.create!(product: product, quantity: 1, price: product.price)
     end
+    subscription = email_subscriptions(:claimed_discount)
 
     @subscriber.emit(build_event("cart.checkout_initiated",
-      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+      payload: { cart_id: cart.id, subscription_id: subscription.id, source: "cart_discount" }))
 
     props = enqueued_klaviyo_job("track")[:properties]
     assert_equal KlaviyoSubscriber::MAX_ITEMS_IN_PAYLOAD, props[:items].length
     assert_equal 21, props[:line_items_count]
   end
 
-  test "cart.checkout_initiated does not enqueue when email is blank" do
+  test "cart.checkout_initiated does not enqueue when the subscription cannot be found" do
     cart = carts(:one)
 
     assert_no_enqueued_jobs do
       @subscriber.emit(build_event("cart.checkout_initiated",
-        payload: { cart_id: cart.id, email: "", source: "cart_discount" }))
+        payload: { cart_id: cart.id, subscription_id: 0, source: "cart_discount" }))
     end
   end
 
   test "cart.checkout_initiated does nothing when the cart cannot be found" do
+    subscription = email_subscriptions(:claimed_discount)
+
     assert_no_enqueued_jobs do
       @subscriber.emit(build_event("cart.checkout_initiated",
-        payload: { cart_id: 0, email: "buyer@cafe.co.uk" }))
+        payload: { cart_id: 0, subscription_id: subscription.id }))
     end
   end
 
   test "cart.checkout_initiated does not enqueue when the cart has no items" do
     empty = Cart.create!
+    subscription = email_subscriptions(:claimed_discount)
 
     assert_no_enqueued_jobs do
       @subscriber.emit(build_event("cart.checkout_initiated",
-        payload: { cart_id: empty.id, email: "buyer@cafe.co.uk" }))
+        payload: { cart_id: empty.id, subscription_id: subscription.id }))
     end
   end
 

--- a/test/subscribers/klaviyo_subscriber_test.rb
+++ b/test/subscribers/klaviyo_subscriber_test.rb
@@ -218,6 +218,24 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
     assert_in_delta item.price.to_f, line[:price], 0.001
   end
 
+  test "cart.checkout_initiated caps the items array but reports the true line_items_count" do
+    cart = Cart.create!
+    21.times do |i|
+      product = Product.create!(
+        category: categories(:cups), name: "Cap Test #{i}",
+        sku: "CAP-TEST-#{i}", price: 5.00, pac_size: 50, active: true
+      )
+      cart.cart_items.create!(product: product, quantity: 1, price: product.price)
+    end
+
+    @subscriber.emit(build_event("cart.checkout_initiated",
+      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+
+    props = enqueued_klaviyo_job("track")[:properties]
+    assert_equal KlaviyoSubscriber::MAX_ITEMS_IN_PAYLOAD, props[:items].length
+    assert_equal 21, props[:line_items_count]
+  end
+
   test "cart.checkout_initiated does not enqueue when email is blank" do
     cart = carts(:one)
 

--- a/test/subscribers/klaviyo_subscriber_test.rb
+++ b/test/subscribers/klaviyo_subscriber_test.rb
@@ -184,6 +184,65 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
     end
   end
 
+  # --- cart.checkout_initiated (abandoned-cart trigger) ---
+
+  test "cart.checkout_initiated enqueues a Started Checkout track job with the cart total as value" do
+    cart = carts(:one) # cart_items(:one): product :one, quantity 2, price 10
+
+    @subscriber.emit(build_event("cart.checkout_initiated",
+      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+
+    track = enqueued_klaviyo_job("track")
+    assert track, "expected a track job to be enqueued"
+    assert_equal "Started Checkout", track[:metric]
+    assert_equal "buyer@cafe.co.uk", track[:email]
+    assert_in_delta cart.total_amount.to_f, track[:value], 0.001
+  end
+
+  test "cart.checkout_initiated properties carry item_count, line_items_count, items and checkout_url" do
+    cart = carts(:one)
+    item = cart_items(:one)
+
+    @subscriber.emit(build_event("cart.checkout_initiated",
+      payload: { cart_id: cart.id, email: "buyer@cafe.co.uk", source: "cart_discount" }))
+
+    props = enqueued_klaviyo_job("track")[:properties]
+    assert_equal cart.items_count, props[:item_count]
+    assert_equal cart.line_items_count, props[:line_items_count]
+    assert props[:checkout_url].present?, "expected a recovery checkout_url"
+
+    assert_equal 1, props[:items].length
+    line = props[:items].first.symbolize_keys
+    assert_equal item.product.name, line[:name]
+    assert_equal item.quantity, line[:quantity]
+    assert_in_delta item.price.to_f, line[:price], 0.001
+  end
+
+  test "cart.checkout_initiated does not enqueue when email is blank" do
+    cart = carts(:one)
+
+    assert_no_enqueued_jobs do
+      @subscriber.emit(build_event("cart.checkout_initiated",
+        payload: { cart_id: cart.id, email: "", source: "cart_discount" }))
+    end
+  end
+
+  test "cart.checkout_initiated does nothing when the cart cannot be found" do
+    assert_no_enqueued_jobs do
+      @subscriber.emit(build_event("cart.checkout_initiated",
+        payload: { cart_id: 0, email: "buyer@cafe.co.uk" }))
+    end
+  end
+
+  test "cart.checkout_initiated does not enqueue when the cart has no items" do
+    empty = Cart.create!
+
+    assert_no_enqueued_jobs do
+      @subscriber.emit(build_event("cart.checkout_initiated",
+        payload: { cart_id: empty.id, email: "buyer@cafe.co.uk" }))
+    end
+  end
+
   private
 
   def build_event(name, payload: {})


### PR DESCRIPTION
## What & why

Adds the abandoned-cart email flow the Klaviyo integration (#213) deliberately left as a follow-up. `KlaviyoSubscriber` already noted: *"Abandoned-cart capture is a separate flow that triggers only once an email is known."* This is that flow.

We email visitors who put items in their cart and gave us their email (via the cart-discount signup), nudging them back before they drop off.

## Approach

The key fact: `EmailSubscriptionsController < ApplicationController`, whose `set_current_cart` before_action populates `Current.cart`. So inside `#create`, the typed email **and** the cart contents coexist in one request. That request is the trigger. No Stripe dependency, no background scan, no email column on carts.

```
EmailSubscriptionsController#create (success + non-empty, non-sample-only cart)
  └─ Rails.event.notify("cart.checkout_initiated", cart_id:, email:, source:)
       └─ KlaviyoSubscriber#handle_checkout_initiated
            └─ KlaviyoEventJob → KlaviyoService.track("Started Checkout", value: cart total)
```

Detection is **Klaviyo-native**: the delay and the *"Placed Order zero times since starting"* suppression live in a Klaviyo Flow (configured in the dashboard). The existing `order.placed → "Placed Order"` event is the conversion signal, so no suppression logic lives in Rails.

## Changes

- **`cart.checkout_initiated` event** — emitted on successful discount signup, guarded on `cart.cart_items.any? && !cart.only_samples?` (sample-only carts are £0, excluded like `order.placed` treats sample requests).
- **`KlaviyoSubscriber#handle_checkout_initiated`** — reloads the cart (mirroring `handle_order_placed`), builds the line items with no N+1, tracks `"Started Checkout"` with the cart total as `value` plus a recovery `checkout_url`.
- **Signed cart-resume route** — `GET /cart/resume?token=...` re-binds the visitor's session to the exact cart so the email link works cross-device. `Cart#signed_recovery_token` / `find_by_recovery_token` reuse the proven `Order#signed_access_token` pattern (`to_sgid` / `GlobalID::Locator`) with a **distinct `"cart_recovery"` purpose**, so an order token can't be replayed as a cart token. Only guest carts are re-bound; a user-owned cart is never hijacked from a link.

`KlaviyoService` and `KlaviyoEventJob` are **unchanged** — `track` already supports a monetary `value:`.

## Decisions / notes for reviewers

- **Sample-only carts excluded** (zero value).
- **Logged-in user, typed email ≠ account email:** we use the **typed** email, consistent with the discount flow's own keying. A logged-in user could thus create a Started Checkout against a profile differing from their account email. Conscious choice for v1.
- **Email value in event tests:** `:email` is in `config.filter_parameters`, so `Rails.event` redacts it in captured payloads. Controller tests assert observable fields (`cart_id`, `source`); the subscriber tests assert email fidelity from the raw payload.

## Out of scope (manual, in Klaviyo dashboard)

Create a Flow triggered by the `Started Checkout` metric → time delay (e.g. 1h / 24h) → flow filter *"Placed Order zero times since starting this flow"* → template looping the `items` property, CTA → `checkout_url`.

## Testing

TDD throughout (red → green). New/affected: subscriber, model token round-trip + purpose isolation, controller emit branches, resume-route (rebind / invalid-token no-op / no user-cart hijack). Full regression across subscribers, jobs, and cart_items passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)