### PR TITLE
Klaviyo abandoned-cart trigger for logged-in users

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -24,6 +24,8 @@ class CheckoutsController < ApplicationController
       # is filtered). Skip when a discount code is set: the form already fired the
       # trigger this session, and we don't want a duplicate. Sample-only carts are
       # excluded (zero value), mirroring order.placed's sample handling.
+      # The discount_code de-dupe is session-scoped, so a cross-device form-then-
+      # checkout can still fire twice; Klaviyo's Flow dedupes the actual send.
       if Current.user && cart.cart_items.any? && !cart.only_samples? && session[:discount_code].blank?
         Rails.event.notify("cart.checkout_initiated",
           cart_id: cart.id,

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -17,6 +17,21 @@ class CheckoutsController < ApplicationController
         subtotal: cart.subtotal_amount
       )
 
+      # Abandoned-cart trigger for logged-in users. Guests fire this from the
+      # discount-signup form; logged-in users have no such form moment (repeat
+      # customers never see it), so we fire here where Current.user and the cart
+      # coexist. KlaviyoSubscriber resolves the email from user_id (payload[:email]
+      # is filtered). Skip when a discount code is set: the form already fired the
+      # trigger this session, and we don't want a duplicate. Sample-only carts are
+      # excluded (zero value), mirroring order.placed's sample handling.
+      if Current.user && cart.cart_items.any? && !cart.only_samples? && session[:discount_code].blank?
+        Rails.event.notify("cart.checkout_initiated",
+          cart_id: cart.id,
+          user_id: Current.user.id,
+          source: "checkout"
+        )
+      end
+
       builder = Checkout::SessionBuilder.new(
         cart: cart,
         user: Current.user,

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -26,6 +26,9 @@ class CheckoutsController < ApplicationController
       # excluded (zero value), mirroring order.placed's sample handling.
       # The discount_code de-dupe is session-scoped, so a cross-device form-then-
       # checkout can still fire twice; Klaviyo's Flow dedupes the actual send.
+      # Fires before SessionBuilder by design (like checkout.started above): a
+      # later Stripe failure still counts as intent, and the Flow's "Placed Order
+      # zero times" filter suppresses the email if they never complete.
       if Current.user && cart.cart_items.any? && !cart.only_samples? && session[:discount_code].blank?
         Rails.event.notify("cart.checkout_initiated",
           cart_id: cart.id,

--- a/app/subscribers/klaviyo_subscriber.rb
+++ b/app/subscribers/klaviyo_subscriber.rb
@@ -12,17 +12,19 @@
 # checkout.started is intentionally NOT handled here: it carries no email at the
 # point of emission (the customer enters their email on Stripe's hosted page),
 # so there is no profile to attach. Abandoned-cart capture rides on
-# cart.checkout_initiated instead, which the discount-signup flow emits once an
-# email IS known. Like order.placed, the cart is reloaded by id; the abandoned-
-# cart delay and suppression ("Placed Order zero times") live in a Klaviyo Flow,
-# so no scheduling or suppression logic lives here.
+# cart.checkout_initiated instead, emitted once an email IS known: the
+# discount-signup flow emits it for guests (carrying subscription_id), and
+# CheckoutsController emits it for logged-in users (carrying user_id). Like
+# order.placed, the cart is reloaded by id; the abandoned-cart delay and
+# suppression ("Placed Order zero times") live in a Klaviyo Flow, so no
+# scheduling or suppression logic lives here.
 #
 # Email handling: Rails.event filters payload values whose keys match
 # config.filter_parameters (by substring), and :email is one of them, so
 # payload[:email] arrives as "[FILTERED]". Every handler therefore resolves the
-# real address from a record (EmailSubscription via subscription_id, or Order via
-# order_id), never from the payload. The id key avoids the "email" substring so
-# the filter does not redact it too.
+# real address from a record (EmailSubscription via subscription_id, User via
+# user_id, or Order via order_id), never from the payload. The id keys avoid the
+# "email" substring so the filter does not redact them too.
 #
 # Like DatafastSubscriber, this only enqueues background jobs; it never performs
 # network I/O inline and never raises into the emitting business code.
@@ -50,7 +52,7 @@ class KlaviyoSubscriber
   private
 
   def handle_signup(payload)
-    email = subscription_email(payload)
+    email = resolve_email(payload)
     return if email.blank?
 
     # NOTE: payload[:discount_eligible] is deliberately not forwarded. The emitter
@@ -74,7 +76,7 @@ class KlaviyoSubscriber
   # recovery link. Klaviyo's Flow owns the delay and "Placed Order zero times"
   # suppression.
   def handle_checkout_initiated(payload)
-    email = subscription_email(payload)
+    email = resolve_email(payload)
     return if email.blank?
 
     cart = Cart.find_by(id: payload[:cart_id])
@@ -148,14 +150,18 @@ class KlaviyoSubscriber
     KlaviyoEventJob.perform_later("track", **args)
   end
 
-  # Resolves the profile email from the EmailSubscription record rather than the
-  # payload: Rails.event filters :email (it is in config.filter_parameters), so
-  # payload[:email] arrives as "[FILTERED]". Mirrors how handle_order_placed reads
-  # Order#email from order_id instead of trusting the payload. The id key is
-  # "subscription_id" (not "email_subscription_id") because the filter matches by
-  # substring and would otherwise redact any key containing "email" too.
-  def subscription_email(payload)
-    EmailSubscription.find_by(id: payload[:subscription_id])&.email
+  # Resolves the profile email from a record rather than the payload: Rails.event
+  # filters :email (it is in config.filter_parameters), so payload[:email] arrives
+  # as "[FILTERED]". Guests carry subscription_id (the discount-signup flow);
+  # logged-in users carry user_id (the checkout flow). Mirrors how
+  # handle_order_placed reads Order#email from order_id. The id keys avoid the
+  # "email" substring, which the filter matches and would otherwise redact too.
+  def resolve_email(payload)
+    if payload[:subscription_id]
+      EmailSubscription.find_by(id: payload[:subscription_id])&.email
+    elsif payload[:user_id]
+      User.find_by(id: payload[:user_id])&.email_address
+    end
   end
 
   # Klaviyo profiles use separate first/last name fields. shipping_name is a

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -932,6 +932,18 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "does not emit cart.checkout_initiated for a logged-in user with an empty cart" do
+    # only_samples? is false for an empty cart, so the explicit cart_items.any?
+    # guard is what blocks this; assert it directly rather than rely on it.
+    Current.stubs(:user).returns(@user)
+    @cart.cart_items.destroy_all
+    stub_stripe_session_create
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post checkout_path
+    end
+  end
+
   test "emits checkout.completed event on successful payment verification" do
     session = stub_stripe_session_retrieve(
       customer_email: "buyer@example.com",

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -876,6 +876,59 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_response :see_other
   end
 
+  # --- cart.checkout_initiated for logged-in users (abandoned-cart trigger) ---
+  #
+  # Guests fire this from the discount-signup form; logged-in users (whose email
+  # we already know) fire it here, where Current.user and Current.cart coexist.
+  # The payload carries user_id (not the filtered email); KlaviyoSubscriber
+  # resolves User#email_address from it. Klaviyo's Flow owns delay/suppression.
+  test "emits cart.checkout_initiated with user_id for a logged-in user with a paid cart" do
+    Current.stubs(:user).returns(@user)
+    stub_stripe_session_create
+
+    assert_event_reported("cart.checkout_initiated",
+      payload: {
+        cart_id: @cart.id,
+        user_id: @user.id,
+        source: "checkout"
+      }
+    ) do
+      post checkout_path
+    end
+  end
+
+  test "does not emit cart.checkout_initiated for a guest checkout" do
+    # No Current.user stub: a guest reaching checkout has no known email here.
+    Current.stubs(:user).returns(nil)
+    stub_stripe_session_create
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post checkout_path
+    end
+  end
+
+  test "does not emit cart.checkout_initiated when a discount code is already in the session" do
+    # The visitor already signed up via the discount form this session, which
+    # fired the trigger; suppress the duplicate from checkout.
+    Current.stubs(:user).returns(@user)
+    post email_subscriptions_path, params: { email: "noorders@example.com" }
+    stub_stripe_session_create
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post checkout_path
+    end
+  end
+
+  test "does not emit cart.checkout_initiated for a logged-in user with a sample-only cart" do
+    Current.stubs(:user).returns(@user)
+    @cart.cart_items.update_all(is_sample: true, price: 0)
+    stub_stripe_session_create
+
+    assert_no_event_reported("cart.checkout_initiated") do
+      post checkout_path
+    end
+  end
+
   test "emits checkout.completed event on successful payment verification" do
     session = stub_stripe_session_retrieve(
       customer_email: "buyer@example.com",

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -912,6 +912,9 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     # fired the trigger; suppress the duplicate from checkout.
     Current.stubs(:user).returns(@user)
     post email_subscriptions_path, params: { email: "noorders@example.com" }
+    assert session[:discount_code].present?, "setup: discount code should be in session"
+    # With a code in session, checkout validates the coupon against Stripe; stub it.
+    Stripe::Coupon.stubs(:retrieve).returns(stub(id: "WELCOME5"))
     stub_stripe_session_create
 
     assert_no_event_reported("cart.checkout_initiated") do

--- a/test/subscribers/klaviyo_subscriber_test.rb
+++ b/test/subscribers/klaviyo_subscriber_test.rb
@@ -282,6 +282,15 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
     end
   end
 
+  test "cart.checkout_initiated does not enqueue when neither subscription_id nor user_id is present" do
+    cart = carts(:one)
+
+    assert_no_enqueued_jobs do
+      @subscriber.emit(build_event("cart.checkout_initiated",
+        payload: { cart_id: cart.id, source: "checkout" }))
+    end
+  end
+
   test "cart.checkout_initiated does nothing when the cart cannot be found" do
     subscription = email_subscriptions(:claimed_discount)
 

--- a/test/subscribers/klaviyo_subscriber_test.rb
+++ b/test/subscribers/klaviyo_subscriber_test.rb
@@ -257,6 +257,31 @@ class KlaviyoSubscriberTest < ActiveJob::TestCase
     end
   end
 
+  # Logged-in users have no EmailSubscription; the trigger fires from
+  # CheckoutsController#create and carries user_id instead, which the subscriber
+  # resolves to User#email_address (the payload email is filtered out, as ever).
+  test "cart.checkout_initiated resolves the email from user_id for a logged-in user" do
+    cart = carts(:one)
+    user = users(:one)
+
+    @subscriber.emit(build_event("cart.checkout_initiated",
+      payload: { cart_id: cart.id, email: "[FILTERED]", user_id: user.id, source: "checkout" }))
+
+    track = enqueued_klaviyo_job("track")
+    assert track, "expected a track job to be enqueued"
+    assert_equal "Started Checkout", track[:metric]
+    assert_equal user.email_address, track[:email]
+  end
+
+  test "cart.checkout_initiated does not enqueue when the user cannot be found" do
+    cart = carts(:one)
+
+    assert_no_enqueued_jobs do
+      @subscriber.emit(build_event("cart.checkout_initiated",
+        payload: { cart_id: cart.id, user_id: 0, source: "checkout" }))
+    end
+  end
+
   test "cart.checkout_initiated does nothing when the cart cannot be found" do
     subscription = email_subscriptions(:claimed_discount)
 


### PR DESCRIPTION
## What & why

Follow-up to #214, which wired the abandoned-cart `Started Checkout` flow for **guests** (fired from the discount-signup form, where email + cart coexist). Logged-in users were explicitly deferred. This PR closes that gap.

The key realisation: logged-in users **without orders** *do* see the discount form (`show_discount_signup?` shows it to them), so they already trigger via the guest path. The population genuinely missing a trigger is:

- **Repeat customers** — the discount is new-customer-only, so they never see the form and have no email-capture moment at all.
- **No-order users who reach checkout without submitting the form.**

The natural trigger point for both is `CheckoutsController#create`: it's the one place a logged-in user's known email and their cart coexist, and it already emits `checkout.started` there.

## Changes

**`CheckoutsController#create`** — emit `cart.checkout_initiated` right after the existing `checkout.started`:

```ruby
if Current.user && cart.cart_items.any? && !cart.only_samples? && session[:discount_code].blank?
  Rails.event.notify("cart.checkout_initiated",
    cart_id: cart.id,
    user_id: Current.user.id,
    source: "checkout"
  )
end
```

- **`user_id`, not the email** — `Rails.event` filters `payload[:email]` to `"[FILTERED]"` (the bug fixed in #214); the subscriber resolves the address from a record instead.
- **`session[:discount_code].blank?`** de-dupes: a user who used the discount form this session already fired the trigger, so checkout suppresses the duplicate.
- **Sample-only carts excluded** (zero value), mirroring `order.placed`'s sample handling and the guest path.
- **`source: "checkout"`** distinguishes these from the form's `"cart_discount"` if you want to segment in Klaviyo.

**`KlaviyoSubscriber`** — generalised email resolution (`subscription_email` → `resolve_email`) to resolve `User#email_address` via `user_id`, alongside the existing `EmailSubscription` via `subscription_id`. Same record-not-payload pattern that sidesteps the `filter_parameters` redaction. Everything downstream (line items, recovery URL, `Started Checkout` metric + value) is unchanged.

## Scope notes

- **No Rails-side scheduling/suppression** — the delay and "Placed Order zero times" suppression live in the existing Klaviyo Flow, which handles these events unchanged.
- **Guests** still fire only from the form (`Current.user &&` short-circuits for them) — no behaviour change to the #214 path.

## Testing

TDD red → green. New coverage:

- Subscriber resolves `User#email_address` from `user_id`; missing user → no enqueue.
- Controller: logged-in user emits with `user_id`; guest does **not** emit; discount-code-in-session suppresses the duplicate; sample-only cart excluded.

119 affected tests green (subscriber, checkouts, guest email-subscriptions path, Datafast + EventLog regressions); RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)