### PR TITLE
Extract OrderTotals module for the order-totals formula

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# afida shop
+
+The domain glossary for an eco-friendly packaging e-commerce shop (UK, B2B-leaning). This file is a glossary only: it names concepts and the words we use for them, not how they are implemented.
+
+## Language
+
+### Money
+
+**Order totals**:
+The money quartet shown for a basket or order: subtotal, VAT, shipping, total. Derived from a subtotal by applying the VAT rate and the free-shipping rule. The same four numbers must be computed one way everywhere they appear.
+_Avoid_: amounts, pricing, cost breakdown.
+
+**Deferred shipping**:
+The stance taken before a customer reaches Stripe: the shipping line is not yet known, so it is omitted and the total is subtotal plus VAT only. Used by the cart and reorder previews, which show "calculated at checkout".
+_Avoid_: pending shipping, TBD shipping.
+
+**Charged shipping**:
+The stance taken when shipping is fixed at order time: the free-shipping threshold decides whether shipping is free or the standard cost, and the total includes it. Used when a reorder snapshot is frozen.
+_Avoid_: final shipping, applied shipping.
+
+**Subtotal**:
+The sum of line totals before VAT and before shipping. Each surface knows how to sum its own lines (cart items, snapshot lines, schedule items); the resulting figure is the input to the order totals.
+_Avoid_: net, pre-tax amount, goods total.
+
+**Free-shipping threshold**:
+The subtotal (excluding VAT) at or above which standard UK delivery is free. A round figure, env-overridable.
+_Avoid_: free delivery minimum, free-ship cutoff.

--- a/app/controllers/reorder_schedules_controller.rb
+++ b/app/controllers/reorder_schedules_controller.rb
@@ -2,6 +2,7 @@
 
 class ReorderSchedulesController < ApplicationController
   before_action :set_schedule, only: [ :show, :edit, :update, :pause, :resume, :skip_next, :destroy ]
+  before_action :eager_load_schedule_items, only: :show
   before_action :set_order, only: [ :setup, :create ]
 
   # GET /reorder_schedules
@@ -153,13 +154,18 @@ class ReorderSchedulesController < ApplicationController
   end
 
   def set_schedule
-    # Eager-load items (and their products) so the show page can both list them
-    # and compute totals (reorder_schedule_totals) without a second query.
-    @schedule = Current.user.reorder_schedules
-                            .includes(reorder_schedule_items: :product)
-                            .find(params[:id])
+    @schedule = Current.user.reorder_schedules.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to reorder_schedules_path, alert: "Schedule not found"
+  end
+
+  # Only the show page lists items and computes totals (reorder_schedule_totals),
+  # so only it pays for eager-loading them. The other actions (edit/update/pause/
+  # resume/skip_next/destroy) don't touch items, so set_schedule does a plain find.
+  def eager_load_schedule_items
+    @schedule = Current.user.reorder_schedules
+                            .includes(reorder_schedule_items: :product)
+                            .find(@schedule.id)
   end
 
   def set_order

--- a/app/controllers/reorder_schedules_controller.rb
+++ b/app/controllers/reorder_schedules_controller.rb
@@ -153,7 +153,11 @@ class ReorderSchedulesController < ApplicationController
   end
 
   def set_schedule
-    @schedule = Current.user.reorder_schedules.find(params[:id])
+    # Eager-load items (and their products) so the show page can both list them
+    # and compute totals (reorder_schedule_totals) without a second query.
+    @schedule = Current.user.reorder_schedules
+                            .includes(reorder_schedule_items: :product)
+                            .find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to reorder_schedules_path, alert: "Schedule not found"
   end

--- a/app/helpers/reorder_schedules_helper.rb
+++ b/app/helpers/reorder_schedules_helper.rb
@@ -8,4 +8,13 @@ module ReorderSchedulesHelper
     total = number_to_currency(order.total_amount, unit: "£")
     "#{pluralize(count, 'item')} · #{total} per delivery"
   end
+
+  # The order totals shown on a reorder schedule's preview. Sums the schedule's
+  # items into a subtotal, then derives VAT and total through OrderTotals so the
+  # formula matches the cart rather than the view hardcoding the VAT rate.
+  # :deferred — the preview shows shipping as "calculated at checkout".
+  def reorder_schedule_totals(schedule)
+    subtotal = schedule.reorder_schedule_items.sum { |item| item.price * item.quantity }
+    OrderTotals.for(subtotal, shipping: :deferred)
+  end
 end

--- a/app/helpers/reorder_schedules_helper.rb
+++ b/app/helpers/reorder_schedules_helper.rb
@@ -9,12 +9,11 @@ module ReorderSchedulesHelper
     "#{pluralize(count, 'item')} · #{total} per delivery"
   end
 
-  # The order totals shown on a reorder schedule's preview. Sums the schedule's
-  # items into a subtotal, then derives VAT and total through OrderTotals so the
+  # The order totals shown on a reorder schedule's preview. The schedule owns
+  # summing its items into a subtotal; OrderTotals derives VAT and total so the
   # formula matches the cart rather than the view hardcoding the VAT rate.
   # :deferred — the preview shows shipping as "calculated at checkout".
   def reorder_schedule_totals(schedule)
-    subtotal = schedule.reorder_schedule_items.sum { |item| item.price * item.quantity }
-    OrderTotals.for(subtotal, shipping: :deferred)
+    OrderTotals.for(schedule.subtotal_amount, shipping: :deferred)
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -50,15 +50,17 @@ class Cart < ApplicationRecord
   end
 
   # Calculate VAT at UK rate (20%)
-  # Uses global VAT_RATE constant from config/initializers/vat.rb
+  # Delegates to OrderTotals, the single home for the order-totals formula. The
+  # cart takes the :deferred shipping stance: shipping is added later at checkout
+  # via Stripe, so it carries no shipping line here.
   def vat_amount
-    subtotal_amount * VAT_RATE
+    cart_totals.vat
   end
 
-  # Final total including VAT
-  # Note: Shipping cost is added separately at checkout via Stripe
+  # Final total including VAT (no shipping; see vat_amount).
+  # Note: Shipping cost is added separately at checkout via Stripe.
   def total_amount
-    subtotal_amount + vat_amount
+    cart_totals.total
   end
 
   # Check if this is a guest cart (not associated with a user)
@@ -72,6 +74,7 @@ class Cart < ApplicationRecord
     @items_count = nil
     @line_items_count = nil
     @subtotal_amount = nil
+    @cart_totals = nil
     @sample_product_ids = nil
     @regular_product_ids = nil
     super
@@ -141,6 +144,13 @@ class Cart < ApplicationRecord
   end
 
   private
+
+  # The cart's order totals, computed once per request. Memoized like
+  # subtotal_amount (and cleared in reload) so vat_amount and total_amount don't
+  # each recompute. :deferred — the cart never shows a shipping line.
+  def cart_totals
+    @cart_totals ||= OrderTotals.for(subtotal_amount, shipping: :deferred)
+  end
 
   # Action Mailer's host, configured in every environment. recovery_url runs
   # inline in KlaviyoSubscriber (a synchronous Rails.event subscriber), so a nil

--- a/app/models/reorder_schedule.rb
+++ b/app/models/reorder_schedule.rb
@@ -58,6 +58,12 @@ class ReorderSchedule < ApplicationRecord
     update!(status: :cancelled, cancelled_at: Time.current)
   end
 
+  # Sum of the schedule's line items (mirrors Cart#subtotal_amount). The order-totals
+  # formula (VAT, shipping) lives in OrderTotals; this owns only the aggregation.
+  def subtotal_amount
+    reorder_schedule_items.sum(&:subtotal_amount)
+  end
+
   private
 
   def items_being_modified?

--- a/app/models/reorder_schedule_item.rb
+++ b/app/models/reorder_schedule_item.rb
@@ -15,4 +15,10 @@ class ReorderScheduleItem < ApplicationRecord
   def current_price
     product.price
   end
+
+  # Line total at the stored price (mirrors CartItem#subtotal_amount). The stored
+  # price is frozen at setup time, so this is independent of later product changes.
+  def subtotal_amount
+    price * quantity
+  end
 end

--- a/app/services/order_totals.rb
+++ b/app/services/order_totals.rb
@@ -64,13 +64,15 @@ class OrderTotals
   end
 
   def result
-    vat = self.vat
-    shipping = self.shipping
+    # Compute each component once; total reuses both, so locals avoid recomputing
+    # vat and shipping a second time.
+    vat_amount = vat
+    shipping_amount = shipping
     Result.new(
       subtotal: @subtotal,
-      vat: vat,
-      shipping: shipping,
-      total: @subtotal + vat + (shipping || 0)
+      vat: vat_amount,
+      shipping: shipping_amount,
+      total: @subtotal + vat_amount + (shipping_amount || 0)
     )
   end
 
@@ -84,7 +86,7 @@ class OrderTotals
   def shipping
     return nil if @shipping_stance == :deferred
 
-    @subtotal >= Shipping::FREE_SHIPPING_THRESHOLD ? BigDecimal(0) : standard_cost
+    @subtotal >= Shipping::FREE_SHIPPING_THRESHOLD ? BigDecimal("0") : standard_cost
   end
 
   def standard_cost

--- a/app/services/order_totals.rb
+++ b/app/services/order_totals.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Single source of truth for the order-totals formula: given a subtotal, apply the
+# VAT rate and the free-shipping rule to produce {subtotal, vat, shipping, total}.
+#
+# This formula used to be re-derived in three places that drifted apart — Cart, the
+# pending-order snapshot builder, and a reorder view that hardcoded `subtotal * 0.2`.
+# Callers still sum their own line items into a subtotal (a cart item, a snapshot
+# hash and a schedule item are different shapes); OrderTotals owns only the rules,
+# which are what actually duplicated and drifted.
+#
+# Shipping stance (see CONTEXT.md):
+#   :deferred — shipping not known yet (cart, reorder preview). No shipping line;
+#               total = subtotal + vat. The cart shows "calculated at checkout".
+#   :charged  — shipping fixed at order time (snapshot). Free at/above the
+#               free-shipping threshold, otherwise the standard cost; total includes it.
+#
+# Components are full-precision BigDecimals so display callers can round once, at the
+# view, via number_to_currency (unchanged behaviour). Callers that must persist money
+# to pennies (the snapshot) call #rounded, which rounds each component to 2dp and
+# keeps the parts summing to the rounded total.
+#
+# The VAT rate and shipping figures are read from their existing homes (VAT_RATE in
+# config/initializers/vat.rb; Shipping::FREE_SHIPPING_THRESHOLD and
+# Shipping.standard_cost_in_pounds) rather than redefined here.
+#
+# Usage:
+#   totals = OrderTotals.for(cart.subtotal_amount, shipping: :deferred)
+#   totals.total                       # subtotal + vat
+#
+#   snapshot = OrderTotals.for(subtotal, shipping: :charged).rounded
+#   snapshot.vat                       # 2dp BigDecimal
+class OrderTotals
+  SHIPPING_STANCES = %i[deferred charged].freeze
+
+  Result = Data.define(:subtotal, :vat, :shipping, :total) do
+    # The same totals with every component rounded to 2dp. total is recomputed from
+    # the rounded parts so "subtotal + vat + shipping == total" holds at penny
+    # precision (avoiding round-then-sum drift). Used when persisting money.
+    def rounded
+      rounded_subtotal = subtotal.round(2)
+      rounded_vat = vat.round(2)
+      rounded_shipping = shipping&.round(2)
+      Result.new(
+        subtotal: rounded_subtotal,
+        vat: rounded_vat,
+        shipping: rounded_shipping,
+        total: rounded_subtotal + rounded_vat + (rounded_shipping || 0)
+      )
+    end
+  end
+
+  def self.for(subtotal, shipping:)
+    new(subtotal, shipping_stance: shipping).result
+  end
+
+  def initialize(subtotal, shipping_stance:)
+    unless SHIPPING_STANCES.include?(shipping_stance)
+      raise ArgumentError, "unknown shipping stance #{shipping_stance.inspect} (expected one of #{SHIPPING_STANCES.inspect})"
+    end
+
+    @subtotal = subtotal
+    @shipping_stance = shipping_stance
+  end
+
+  def result
+    vat = self.vat
+    shipping = self.shipping
+    Result.new(
+      subtotal: @subtotal,
+      vat: vat,
+      shipping: shipping,
+      total: @subtotal + vat + (shipping || 0)
+    )
+  end
+
+  private
+
+  def vat
+    @subtotal * BigDecimal(VAT_RATE.to_s)
+  end
+
+  # nil when deferred (no shipping line yet); 0 or the standard cost when charged.
+  def shipping
+    return nil if @shipping_stance == :deferred
+
+    @subtotal >= Shipping::FREE_SHIPPING_THRESHOLD ? BigDecimal(0) : standard_cost
+  end
+
+  def standard_cost
+    BigDecimal(Shipping.standard_cost_in_pounds.to_s)
+  end
+end

--- a/app/services/pending_order_snapshot_builder.rb
+++ b/app/services/pending_order_snapshot_builder.rb
@@ -46,19 +46,20 @@ class PendingOrderSnapshotBuilder
     build_snapshot(available_items, [])
   end
 
-  # Shared logic for building the final snapshot hash
+  # Shared logic for building the final snapshot hash. The order-totals formula
+  # (VAT + free-shipping rule) lives in OrderTotals; this builder owns summing the
+  # snapshot lines into a subtotal and freezing the money as 2dp strings. :charged
+  # — a frozen snapshot has its shipping fixed at order time.
   def self.build_snapshot(available_items, unavailable_items)
     subtotal = available_items.sum { |item| item["line_total"].to_d }
-    vat = subtotal * VAT_RATE
-    shipping = subtotal >= Shipping::FREE_SHIPPING_THRESHOLD ? 0 : Shipping.standard_cost_in_pounds
-    total = subtotal + vat + shipping
+    totals = OrderTotals.for(subtotal, shipping: :charged)
 
     {
       "items" => available_items,
-      "subtotal" => format_amount(subtotal),
-      "vat" => format_amount(vat),
-      "shipping" => format_amount(shipping),
-      "total" => format_amount(total),
+      "subtotal" => format_amount(totals.subtotal),
+      "vat" => format_amount(totals.vat),
+      "shipping" => format_amount(totals.shipping),
+      "total" => format_amount(totals.total),
       "unavailable_items" => unavailable_items
     }
   end

--- a/app/services/pending_order_snapshot_builder.rb
+++ b/app/services/pending_order_snapshot_builder.rb
@@ -69,6 +69,12 @@ class PendingOrderSnapshotBuilder
   end
 
   def self.format_amount(amount)
+    # A snapshot is always built from a :charged OrderTotals result, so every
+    # component (including shipping) is non-nil. A nil here means a :deferred
+    # result reached the snapshot — a caller bug, not money to format. Fail loudly
+    # rather than raising an opaque TypeError from sprintf.
+    raise ArgumentError, "cannot format a nil amount (a :deferred result has no shipping line)" if amount.nil?
+
     "%.2f" % amount
   end
 

--- a/app/services/pending_order_snapshot_builder.rb
+++ b/app/services/pending_order_snapshot_builder.rb
@@ -52,7 +52,11 @@ class PendingOrderSnapshotBuilder
   # — a frozen snapshot has its shipping fixed at order time.
   def self.build_snapshot(available_items, unavailable_items)
     subtotal = available_items.sum { |item| item["line_total"].to_d }
-    totals = OrderTotals.for(subtotal, shipping: :charged)
+    # .rounded so the persisted total is the sum of the 2dp components, not a
+    # rounded sum of full-precision ones. Identical output for penny-precise
+    # subtotals under 20% VAT, but makes the consistency explicit rather than
+    # incidental to the current rate.
+    totals = OrderTotals.for(subtotal, shipping: :charged).rounded
 
     {
       "items" => available_items,

--- a/app/views/cart_items/_index.html.erb
+++ b/app/views/cart_items/_index.html.erb
@@ -57,7 +57,7 @@
           <div class="flex justify-between text-lg sm:text-xl text-gray-800 border-t pt-3 mt-3">
             <span>Total</span>
             <span id="grand_total">
-              <%= number_to_currency(Current.cart.subtotal_amount + Current.cart.vat_amount) %>
+              <%= number_to_currency(Current.cart.total_amount) %>
             </span>
           </div>
 

--- a/app/views/reorder_schedules/show.html.erb
+++ b/app/views/reorder_schedules/show.html.erb
@@ -96,18 +96,16 @@
       <% end %>
     </div>
 
-    <%# Order totals %>
-    <% subtotal = @schedule.reorder_schedule_items.sum { |i| i.price * i.quantity } %>
-    <% vat = subtotal * 0.2 %>
-    <% total = subtotal + vat %>
+    <%# Order totals (VAT/total via OrderTotals; shipping deferred to checkout) %>
+    <% totals = reorder_schedule_totals(@schedule) %>
     <div class="border-t border-base-200 mt-4 pt-4 space-y-2">
       <div class="flex justify-between text-sm">
         <span class="text-base-content/70">Subtotal</span>
-        <span><%= number_to_currency(subtotal, unit: '£') %></span>
+        <span><%= number_to_currency(totals.subtotal, unit: '£') %></span>
       </div>
       <div class="flex justify-between text-sm">
         <span class="text-base-content/70">VAT (20%)</span>
-        <span><%= number_to_currency(vat, unit: '£') %></span>
+        <span><%= number_to_currency(totals.vat, unit: '£') %></span>
       </div>
       <div class="flex justify-between text-sm">
         <span class="text-base-content/70">Shipping</span>
@@ -115,7 +113,7 @@
       </div>
       <div class="flex justify-between text-lg pt-2 border-t border-base-200">
         <span>Total</span>
-        <span><%= number_to_currency(total, unit: '£') %></span>
+        <span><%= number_to_currency(totals.total, unit: '£') %></span>
       </div>
     </div>
   </div>

--- a/app/views/reorder_schedules/show.html.erb
+++ b/app/views/reorder_schedules/show.html.erb
@@ -68,7 +68,7 @@
     <h2 class="text-lg mb-4">Items in Scheduled Reorder</h2>
 
     <div class="divide-y divide-base-200">
-      <% @schedule.reorder_schedule_items.includes(:product).each do |item| %>
+      <% @schedule.reorder_schedule_items.each do |item| %>
         <div class="py-4 flex justify-between items-center">
           <div class="flex items-center gap-4">
             <% if item.product&.primary_photo&.attached? %>

--- a/test/controllers/reorder_schedules_controller_test.rb
+++ b/test/controllers/reorder_schedules_controller_test.rb
@@ -76,6 +76,35 @@ class ReorderSchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Schedule not found", flash[:alert]
   end
 
+  test "show eager-loads items so listing and totals share one query" do
+    sign_in(@user)
+    schedule = create_schedule_with_items(@user, count: 3)
+
+    queries = capture_table_queries("reorder_schedule_items") do
+      get reorder_schedule_url(schedule)
+    end
+
+    assert_response :success
+    # The view lists items and reorder_schedule_totals sums them; both read the
+    # eager-loaded association, so the items table is hit once, not per read.
+    assert_equal 1, queries,
+      "expected reorder_schedule_items to be loaded once, got #{queries} queries"
+  end
+
+  test "pause does not eager-load items or products" do
+    sign_in(@user)
+    schedule = create_schedule_with_items(@user, count: 3)
+
+    item_queries = capture_table_queries("reorder_schedule_items") do
+      patch pause_reorder_schedule_url(schedule)
+    end
+
+    # pause only flips status and redirects; it never touches items or products,
+    # so set_schedule does a plain find with no items/products JOIN.
+    assert_equal 0, item_queries,
+      "pause should not load reorder_schedule_items, got #{item_queries} queries"
+  end
+
   # ==========================================================================
   # Setup Flow
   # ==========================================================================
@@ -668,5 +697,25 @@ class ReorderSchedulesControllerTest < ActionDispatch::IntegrationTest
       price: product_variant.price
     )
     schedule
+  end
+
+  # A schedule with `count` items, each on a distinct active product, so a missing
+  # eager-load shows up as per-item product queries (an N+1) rather than one JOIN.
+  def create_schedule_with_items(user, count: 3)
+    schedule = create_schedule_for(user)
+    Product.where(active: true).limit(count).each do |product|
+      schedule.reorder_schedule_items.create!(product: product, quantity: 2, price: product.price)
+    end
+    schedule
+  end
+
+  # Counts sql.active_record events whose SQL references the given table.
+  def capture_table_queries(table, &block)
+    count = 0
+    counter = ->(_name, _start, _finish, _id, payload) do
+      count += 1 if payload[:sql]&.include?(%("#{table}"))
+    end
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+    count
   end
 end

--- a/test/helpers/reorder_schedules_helper_test.rb
+++ b/test/helpers/reorder_schedules_helper_test.rb
@@ -61,4 +61,22 @@ class ReorderSchedulesHelperTest < ActionView::TestCase
     assert_includes result, "·"
     assert_match(/\d+ items? · £/, result)
   end
+
+  # reorder_schedule_totals: the schedule preview's order totals, computed through
+  # OrderTotals (:deferred) so the VAT/total formula matches the cart instead of
+  # the view hardcoding `subtotal * 0.2`.
+
+  test "reorder_schedule_totals sums schedule items into a deferred subtotal" do
+    schedule = reorder_schedules(:active_monthly)
+    schedule.reorder_schedule_items.destroy_all
+    schedule.reorder_schedule_items.create!(product: products(:one), price: 50.00, quantity: 2)
+    schedule.reload
+
+    totals = reorder_schedule_totals(schedule)
+
+    assert_equal BigDecimal("100.00"), totals.subtotal
+    assert_equal BigDecimal("20.00"), totals.vat
+    assert_nil totals.shipping # deferred — shipping shown as "calculated at checkout"
+    assert_equal BigDecimal("120.00"), totals.total
+  end
 end

--- a/test/models/reorder_schedule_item_test.rb
+++ b/test/models/reorder_schedule_item_test.rb
@@ -149,4 +149,22 @@ class ReorderScheduleItemTest < ActiveSupport::TestCase
     assert_equal original_price + 5.00, @item.current_price
     assert_equal original_price, @item.price # stored price unchanged
   end
+
+  # ==========================================================================
+  # Subtotal
+  # ==========================================================================
+
+  test "subtotal_amount is stored price times quantity" do
+    @item.price = 12.50
+    @item.quantity = 3
+
+    assert_equal 37.50, @item.subtotal_amount
+  end
+
+  test "subtotal_amount uses the stored price, not the current product price" do
+    @item.save!
+    @product.update!(price: @item.price + 10.00)
+
+    assert_equal @item.price * @item.quantity, @item.subtotal_amount
+  end
 end

--- a/test/models/reorder_schedule_test.rb
+++ b/test/models/reorder_schedule_test.rb
@@ -290,4 +290,24 @@ class ReorderScheduleTest < ActiveSupport::TestCase
 
     assert_equal Date.current + 3.months, @schedule.next_scheduled_date
   end
+
+  # ==========================================================================
+  # Subtotal
+  # ==========================================================================
+
+  test "subtotal_amount sums each item's price times quantity" do
+    schedule = reorder_schedules(:active_monthly)
+    schedule.reorder_schedule_items.destroy_all
+    schedule.reorder_schedule_items.create!(product: products(:one), price: 50.00, quantity: 2)
+    schedule.reorder_schedule_items.create!(product: products(:two), price: 10.00, quantity: 3)
+    schedule.reload
+
+    assert_equal 130.00, schedule.subtotal_amount
+  end
+
+  test "subtotal_amount is zero with no items" do
+    @schedule.save!
+
+    assert_equal 0, @schedule.subtotal_amount
+  end
 end

--- a/test/services/order_totals_test.rb
+++ b/test/services/order_totals_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# OrderTotals owns the order-totals formula: given a subtotal, apply the VAT rate
+# and the free-shipping rule to produce {subtotal, vat, shipping, total}. It is the
+# single home for that formula, which previously drifted across Cart, the snapshot
+# builder, and a reorder view (which hardcoded `subtotal * 0.2`).
+#
+# Two shipping stances (see CONTEXT.md):
+#   :deferred — shipping unknown yet (cart, reorder preview); total = subtotal + vat
+#   :charged  — shipping fixed (snapshot); free over the threshold, else standard cost
+class OrderTotalsTest < ActiveSupport::TestCase
+  STANDARD_COST = BigDecimal(Shipping::STANDARD_COST.to_s) / 100 # e.g. 6.99
+  THRESHOLD = Shipping::FREE_SHIPPING_THRESHOLD                  # e.g. 100
+
+  # ==========================================================================
+  # :deferred — cart / reorder preview (shipping not yet known)
+  # ==========================================================================
+
+  test "deferred omits shipping and totals subtotal plus vat" do
+    totals = OrderTotals.for(BigDecimal("20.00"), shipping: :deferred)
+
+    assert_equal BigDecimal("20.00"), totals.subtotal
+    assert_equal BigDecimal("4.00"), totals.vat
+    assert_nil totals.shipping
+    assert_equal BigDecimal("24.00"), totals.total
+  end
+
+  test "deferred total ignores the free-shipping threshold entirely" do
+    # Even a large subtotal carries no shipping line when deferred.
+    totals = OrderTotals.for(BigDecimal("500.00"), shipping: :deferred)
+
+    assert_nil totals.shipping
+    assert_equal BigDecimal("600.00"), totals.total # 500 + 100 vat
+  end
+
+  # ==========================================================================
+  # :charged — snapshot (shipping fixed at order time)
+  # ==========================================================================
+
+  test "charged below threshold applies standard shipping" do
+    totals = OrderTotals.for(BigDecimal("96.00"), shipping: :charged)
+
+    assert_equal BigDecimal("96.00"), totals.subtotal
+    assert_equal BigDecimal("19.20"), totals.vat
+    assert_equal STANDARD_COST, totals.shipping
+    assert_equal BigDecimal("96.00") + BigDecimal("19.20") + STANDARD_COST, totals.total
+  end
+
+  test "charged above threshold ships free" do
+    totals = OrderTotals.for(BigDecimal("104.00"), shipping: :charged)
+
+    assert_equal BigDecimal("0"), totals.shipping
+    assert_equal BigDecimal("104.00") + BigDecimal("20.80"), totals.total
+  end
+
+  test "charged exactly at threshold ships free (boundary is inclusive)" do
+    totals = OrderTotals.for(THRESHOLD, shipping: :charged)
+
+    assert_equal BigDecimal("0"), totals.shipping
+  end
+
+  test "charged just under threshold still pays standard shipping" do
+    totals = OrderTotals.for(THRESHOLD - BigDecimal("0.01"), shipping: :charged)
+
+    assert_equal STANDARD_COST, totals.shipping
+  end
+
+  # ==========================================================================
+  # VAT rate
+  # ==========================================================================
+
+  test "vat is the configured rate applied to the subtotal, unrounded" do
+    # 33.33 * 0.2 = 6.666 — full precision, not yet rounded to pennies.
+    totals = OrderTotals.for(BigDecimal("33.33"), shipping: :deferred)
+
+    assert_equal BigDecimal("33.33") * BigDecimal(VAT_RATE.to_s), totals.vat
+    assert_equal BigDecimal("6.666"), totals.vat
+  end
+
+  # ==========================================================================
+  # .rounded — used when persisting money to 2dp (the snapshot)
+  # ==========================================================================
+
+  test "rounded returns each component at two decimal places" do
+    rounded = OrderTotals.for(BigDecimal("33.33"), shipping: :charged).rounded
+
+    assert_equal BigDecimal("33.33"), rounded.subtotal
+    assert_equal BigDecimal("6.67"), rounded.vat       # 6.666 -> 6.67
+    assert_equal STANDARD_COST.round(2), rounded.shipping
+    assert_equal BigDecimal("46.99"), rounded.total    # 33.33 + 6.67 + 6.99
+  end
+
+  test "rounded keeps parts summing to the rounded total" do
+    rounded = OrderTotals.for(BigDecimal("33.33"), shipping: :charged).rounded
+
+    sum_of_parts = rounded.subtotal + rounded.vat + rounded.shipping
+    assert_equal rounded.total, sum_of_parts
+  end
+
+  test "rounded deferred leaves shipping nil and sums subtotal plus vat" do
+    rounded = OrderTotals.for(BigDecimal("33.33"), shipping: :deferred).rounded
+
+    assert_nil rounded.shipping
+    assert_equal BigDecimal("40.00"), rounded.total # 33.33 + 6.67
+  end
+
+  # ==========================================================================
+  # Guard rails
+  # ==========================================================================
+
+  test "an unknown shipping stance is rejected" do
+    assert_raises(ArgumentError) do
+      OrderTotals.for(BigDecimal("10.00"), shipping: :whenever)
+    end
+  end
+end

--- a/test/services/pending_order_snapshot_builder_test.rb
+++ b/test/services/pending_order_snapshot_builder_test.rb
@@ -265,6 +265,14 @@ class PendingOrderSnapshotBuilderTest < ActiveSupport::TestCase
     assert_equal "10.13", PendingOrderSnapshotBuilder.format_amount(10.126)
   end
 
+  test "format_amount raises a clear error on nil instead of a TypeError" do
+    # A snapshot always uses the :charged stance, so shipping is never nil here.
+    # Guard the contract explicitly: a nil amount is a caller bug (a :deferred
+    # result reaching the snapshot), not money to format.
+    error = assert_raises(ArgumentError) { PendingOrderSnapshotBuilder.format_amount(nil) }
+    assert_match(/nil/, error.message)
+  end
+
   # ==========================================================================
   # Consistency: Both methods produce same totals
   # ==========================================================================

--- a/test/services/pending_order_snapshot_builder_test.rb
+++ b/test/services/pending_order_snapshot_builder_test.rb
@@ -98,6 +98,17 @@ class PendingOrderSnapshotBuilderTest < ActiveSupport::TestCase
     assert_equal expected_total, snapshot["total"]
   end
 
+  test "persisted total equals the sum of the persisted subtotal, vat and shipping" do
+    # The snapshot freezes money as 2dp strings via OrderTotals#rounded, so the
+    # stored total must reconcile with the stored parts rather than being a rounded
+    # sum of full-precision figures. Guards the consistency the rate currently
+    # makes incidental.
+    snapshot = PendingOrderSnapshotBuilder.new(@schedule).build
+
+    parts = snapshot["subtotal"].to_d + snapshot["vat"].to_d + snapshot["shipping"].to_d
+    assert_equal snapshot["total"].to_d, parts
+  end
+
   test "build marks inactive variant as unavailable" do
     @product.update!(active: false)
 


### PR DESCRIPTION
## What

Introduces `OrderTotals` as the single home for the **order-totals formula** (subtotal → VAT → shipping → total). That formula was re-derived in three places that had drifted apart:

- `Cart#vat_amount` / `#total_amount`
- `PendingOrderSnapshotBuilder.build_snapshot`
- the reorder-schedule view, which hardcoded `subtotal * 0.2` — bypassing `VAT_RATE` entirely

## Design

Callers still sum their own line items into a subtotal (cart items, snapshot hashes and schedule items are different shapes). `OrderTotals` owns only the rules, which are what actually duplicated. A **shipping stance** names the variation that was previously accidental:

```ruby
OrderTotals.for(subtotal, shipping: :deferred) # cart, reorder preview — no shipping line; total = subtotal + vat
OrderTotals.for(subtotal, shipping: :charged)  # snapshot — free at/above threshold, else standard cost
```

- Components stay full-precision `BigDecimal`s, so display callers round once at the view via `number_to_currency` (unchanged behaviour).
- The snapshot, which persists money to pennies, uses `.rounded` — rounds each component to 2dp and keeps the parts summing to the rounded total (kills round-then-sum drift).
- `VAT_RATE` and `Shipping::*` are **referenced, not moved** — this is a correctness change, not a constant reshuffle.

## Call-site impact

| Site | Change |
|---|---|
| `Cart` | `vat_amount`/`total_amount` delegate to a memoized `OrderTotals`; **~20 cart views untouched** |
| `PendingOrderSnapshotBuilder` | inline formula → one `OrderTotals` call; persisted strings **byte-identical** |
| reorder view | inline `* 0.2` lifted into a tested helper (`reorder_schedule_totals`) |
| `cart_items/_index` | total reads `total_amount` (the seam) instead of re-adding `subtotal + vat` |

Also seeds `CONTEXT.md` with the sharpened money vocabulary (*Order totals, Deferred/Charged shipping, Subtotal, Free-shipping threshold*).

## Testing

TDD'd. New `test/services/order_totals_test.rb` (11 tests, no DB) pins both stances, the threshold boundary (£100 → free, inclusive), unrounded VAT, and `.rounded` penny-drift. Characterization guards on `cart_test` and `pending_order_snapshot_builder_test` held green through the swap.

**Behaviour-preserving — full suite green: 2467 runs, 7292 assertions, 0 failures, 0 errors.** The one deliberate fix is the reorder view, which now uses the same formula as the cart.

## Scope note

This sets up a follow-up (an `OrderIntake` module that consumes `OrderTotals`). The live Stripe path is deliberately **out of scope** here — Stripe stays the source of truth for what was charged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)