### PR TITLE
Fix admin category forms posting to dirty slug URLs after rejected updates

### DIFF
--- a/app/views/admin/blog_categories/_form.html.erb
+++ b/app/views/admin/blog_categories/_form.html.erb
@@ -1,4 +1,8 @@
-<%= form_with(model: [:admin, blog_category], local: true, data: { turbo: false }) do |form| %>
+<%# Explicit URL from the persisted slug: to_param returns the dirty slug, so after a
+    rejected slug the default action would point at a URL that no longer resolves. %>
+<%= form_with(model: [:admin, blog_category],
+              url: blog_category.persisted? ? admin_blog_category_path(id: blog_category.slug_in_database) : admin_blog_categories_path,
+              local: true, data: { turbo: false }) do |form| %>
   <% if blog_category.errors.any? %>
     <div class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-md mt-3">
       <h2><%= pluralize(blog_category.errors.count, "error") %> prohibited this category from being saved:</h2>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -1,4 +1,8 @@
-<%= form_with(model: [:admin, category], local: true, class: "space-y-4 sm:space-y-6 max-w-2xl") do |form| %>
+<%# Explicit URL from the persisted slug: to_param returns the dirty slug, so after a
+    rejected slug the default action would point at a URL that no longer resolves. %>
+<%= form_with(model: [:admin, category],
+              url: category.persisted? ? admin_category_path(id: category.slug_in_database) : admin_categories_path,
+              local: true, class: "space-y-4 sm:space-y-6 max-w-2xl") do |form| %>
   <% if category.errors.any? %>
     <div class="alert alert-error">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">

--- a/test/controllers/admin/blog_categories_controller_test.rb
+++ b/test/controllers/admin/blog_categories_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Admin::BlogCategoriesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    # Set a modern browser user agent to pass allow_browser check
+    @headers = { "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" }
+    @blog_category = blog_categories(:guides)
+    @admin = users(:acme_admin)
+    sign_in_as(@admin)
+  end
+
+  def sign_in_as(user)
+    post session_url, params: { email_address: user.email_address, password: "password" }, headers: @headers
+  end
+
+  test "edit form posts to the persisted slug after a malformed slug is rejected" do
+    patch admin_blog_category_path(@blog_category), headers: @headers, params: {
+      blog_category: { slug: "Not A Slug!" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", admin_blog_category_path(@blog_category.reload)
+  end
+
+  test "edit form does not post to another record after a duplicate slug is rejected" do
+    other = blog_categories(:news)
+
+    patch admin_blog_category_path(@blog_category), headers: @headers, params: {
+      blog_category: { slug: other.slug }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", admin_blog_category_path(@blog_category.reload)
+  end
+end

--- a/test/controllers/admin/categories_controller_test.rb
+++ b/test/controllers/admin/categories_controller_test.rb
@@ -151,7 +151,6 @@ class Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
     patch admin_category_path(@category), headers: @headers, params: {
       category: {
         name: ""
-        # Don't set slug to empty as it causes routing issues
       }
     }
 
@@ -159,6 +158,25 @@ class Admin::CategoriesControllerTest < ActionDispatch::IntegrationTest
 
     @category.reload
     assert_equal original_name, @category.name
+  end
+
+  test "edit form posts to the persisted slug after a duplicate slug is rejected" do
+    other = categories(:parent_cups_and_drinks)
+
+    patch admin_category_path(@category), headers: @headers, params: {
+      category: { slug: other.slug }
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "form[action=?]", admin_category_path(@category.reload)
+  end
+
+  test "update with a blank slug re-renders the form instead of crashing" do
+    patch admin_category_path(@category), headers: @headers, params: {
+      category: { slug: "" }
+    }
+
+    assert_response :unprocessable_entity
   end
 
   test "should create subcategory with parent" do


### PR DESCRIPTION
## Summary

Applies the dirty-slug form-action fix from #230's review to the two other vulnerable admin forms. The categories and blog categories forms built their action via `to_param`, which returns the in-memory slug, so after a rejected update the re-rendered form pointed at a URL that no longer resolves:

- **Categories, duplicate slug**: the 422 re-render posted at the *other* category's URL, so resubmitting would overwrite a different record.
- **Categories, blank slug**: `Category` never regenerates slugs, so the re-render raised `UrlGenerationError` (500). The old test suite even carried a "Don't set slug to empty as it causes routing issues" workaround comment, now removed.
- **Blog categories**: same mechanism via its format/uniqueness validations.

Both forms now build their URL from `slug_in_database`, the pattern the collections form already used and #230 adopted. Audited and unaffected: products (`:slug` not permitted in `product_params`) and blog posts (explicit id-based URL).

## Test plan

- [x] 4 new regression tests (2 categories, 2 blog categories in a new test file), all red before the fix and green after
- [x] Full suite: 2615 runs, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)