### PR TITLE
On-site checkout (Stripe custom UI) behind ONSITE_CHECKOUT flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authentication
   include EventContext
+  before_action :capture_onsite_checkout_preview
   before_action :set_current_cart
   before_action :set_nav_categories
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -9,6 +10,21 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  # Session-sticky preview of the on-site checkout: any URL with
+  # ?onsite_checkout=1 turns it on for this browser session, ?onsite_checkout=0
+  # back off, so the mode is testable in production without flipping
+  # ONSITE_CHECKOUT globally. CheckoutsController passes the session to
+  # OnsiteCheckout.enabled?, which honours the flag.
+  def capture_onsite_checkout_preview
+    return unless params.key?(:onsite_checkout)
+
+    if OnsiteCheckout.truthy?(params[:onsite_checkout])
+      session[OnsiteCheckout::PREVIEW_SESSION_KEY] = true
+    else
+      session.delete(OnsiteCheckout::PREVIEW_SESSION_KEY)
+    end
+  end
 
   # 301 to a canonical path, carrying the raw query string through unchanged
   # (same semantics as the redirect blocks in config/routes.rb; avoids the

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -66,7 +66,7 @@ class CheckoutsController < ApplicationController
         datafast_session_id: cookies[:datafast_session_id],
         success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
         cancel_url: cancel_checkout_url,
-        ui_mode: OnsiteCheckout.enabled? ? :custom : :hosted,
+        ui_mode: OnsiteCheckout.enabled?(session) ? :custom : :hosted,
         return_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}"
       )
       result = builder.create
@@ -76,22 +76,30 @@ class CheckoutsController < ApplicationController
         flash[:alert] = "Your discount code could not be applied. Please continue with your order."
       end
 
-      session[:selected_address_id] = result.selected_address_id if result.selected_address_id.present?
+      if result.selected_address_id.present?
+        session[:selected_address_id] = result.selected_address_id
+      else
+        # A checkout with no selection (e.g. from the cart drawer, whose form
+        # has no address selector) must not inherit one from an earlier
+        # attempt: the on-site page would prefill and zone-guard an address
+        # this checkout wasn't priced from.
+        session.delete(:selected_address_id)
+      end
 
-      if OnsiteCheckout.enabled?
-        # Stash the custom-mode session for GET /checkout to render. The
-        # fingerprint is computed AFTER the invalid-discount cleanup above so
-        # both sides of the later staleness comparison see the same (possibly
-        # cleared) discount code — otherwise an invalid welcome code would
-        # false-bounce every render.
+      if OnsiteCheckout.enabled?(session)
+        # Stash the custom-mode session for GET /checkout to render; only
+        # members #show reads belong here (the stash is cookie payload on
+        # every request). The fingerprint is computed AFTER the
+        # invalid-discount cleanup above so both sides of the later staleness
+        # comparison see the same (possibly cleared) discount code: otherwise
+        # an invalid welcome code would false-bounce every render.
         session[:onsite_checkout] = {
-          "session_id" => result.session.id,
           "client_secret" => result.session.client_secret,
           "fingerprint" => Checkout::CartFingerprint.digest(
             cart: cart, postcode: resolved_postcode, discount_code: session[:discount_code]
           ),
-          "postcode" => resolved_postcode,
-          "zone" => result.zone.to_s
+          "zone" => result.zone.to_s,
+          "created_at" => Time.current.to_i
         }
         redirect_to checkout_path, status: :see_other
       else
@@ -105,16 +113,37 @@ class CheckoutsController < ApplicationController
     end
   end
 
+  # Stripe expires Checkout Sessions 24 hours after creation; past that the
+  # stashed client_secret can only produce a dead page whose "please refresh"
+  # advice re-serves the same expired secret. Bounce just short of Stripe's
+  # line so the customer lands on the cart with a working restart instead.
+  ONSITE_STASH_TTL = 23.hours
+
   # The on-site checkout page. Renders the Stripe session stashed by #create;
   # performs no Stripe writes, so refresh and back-navigation are free.
   def show
-    return redirect_to cart_path unless OnsiteCheckout.enabled?
+    unless OnsiteCheckout.enabled?(session)
+      # Flipping the flag off must not strand a stashed client_secret in the
+      # cookie indefinitely.
+      session.delete(:onsite_checkout)
+      return redirect_to cart_path
+    end
 
     stash = session[:onsite_checkout]
     cart = Current.cart
     return redirect_to cart_path if stash.blank? || cart.blank? || cart.cart_items.empty?
 
-    postcode = session[:delivery_postcode].presence || stash["postcode"]
+    if stash["created_at"].to_i < ONSITE_STASH_TTL.ago.to_i
+      session.delete(:onsite_checkout)
+      return redirect_to cart_path, notice: "Your checkout session expired. Continue to payment when you're ready."
+    end
+
+    # Re-resolve the destination exactly as #create did (typed postcode, then
+    # the stashed address selection, then the default address). Falling back
+    # to a postcode recorded in the stash instead would validate the stash
+    # against itself: a postcode REMOVED from the session after #create went
+    # unnoticed, and the page charged a destination the cart no longer shows.
+    postcode = delivery_postcode_for(session[:selected_address_id])
     fingerprint = Checkout::CartFingerprint.digest(
       cart: cart, postcode: postcode, discount_code: session[:discount_code]
     )
@@ -122,6 +151,12 @@ class CheckoutsController < ApplicationController
       session.delete(:onsite_checkout)
       return redirect_to cart_path, notice: "Your basket changed. Continue to payment when you're ready."
     end
+
+    # The summary must price shipping from the destination the Stripe session
+    # was built from. The before_action resolves the cart's postcode without
+    # the address selection, so a saved-address checkout would otherwise
+    # display a different shipping line than the session charges.
+    cart.delivery_postcode = postcode
 
     @client_secret = stash["client_secret"]
     @priced_zone = stash["zone"]
@@ -142,13 +177,17 @@ class CheckoutsController < ApplicationController
     begin
       stripe_session = Stripe::Checkout::Session.retrieve(
         id: session_id,
-        expand: [ "collected_information", "line_items.data.price.product" ]
+        expand: [ "collected_information", "line_items.data.price.product", "payment_intent.payment_method" ]
       )
 
       unless Checkout::COMPLETED_PAYMENT_STATUSES.include?(stripe_session.payment_status)
         flash[:error] = "Payment was not completed successfully"
         return redirect_to cart_path
       end
+
+      # The stash's job ends with payment: without this the paid session's
+      # client_secret would ride every later request's cookie.
+      session.delete(:onsite_checkout)
 
       # Check if order already exists for this session (webhook may have created it)
       existing_order = Order.find_by(stripe_session_id: session_id)
@@ -169,7 +208,7 @@ class CheckoutsController < ApplicationController
       Rails.event.notify("checkout.completed",
         order_id: order.id,
         total: order.total_amount.to_f,
-        payment_method: stripe_session.payment_method_types&.first || "card"
+        payment_method: Checkout::SessionDetails.payment_method_type(stripe_session)
       )
 
       # Emit order.placed event

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -54,16 +54,20 @@ class CheckoutsController < ApplicationController
         )
       end
 
+      resolved_postcode = delivery_postcode_for(params[:address_id])
+
       builder = Checkout::SessionBuilder.new(
         cart: cart,
         user: Current.user,
         address_id: params[:address_id],
         discount_code: session[:discount_code],
-        delivery_postcode: delivery_postcode_for(params[:address_id]),
+        delivery_postcode: resolved_postcode,
         datafast_visitor_id: cookies[:datafast_visitor_id],
         datafast_session_id: cookies[:datafast_session_id],
         success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
-        cancel_url: cancel_checkout_url
+        cancel_url: cancel_checkout_url,
+        ui_mode: OnsiteCheckout.enabled? ? :custom : :hosted,
+        return_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}"
       )
       result = builder.create
 
@@ -74,7 +78,25 @@ class CheckoutsController < ApplicationController
 
       session[:selected_address_id] = result.selected_address_id if result.selected_address_id.present?
 
-      redirect_to result.session.url, allow_other_host: true, status: :see_other
+      if OnsiteCheckout.enabled?
+        # Stash the custom-mode session for GET /checkout to render. The
+        # fingerprint is computed AFTER the invalid-discount cleanup above so
+        # both sides of the later staleness comparison see the same (possibly
+        # cleared) discount code — otherwise an invalid welcome code would
+        # false-bounce every render.
+        session[:onsite_checkout] = {
+          "session_id" => result.session.id,
+          "client_secret" => result.session.client_secret,
+          "fingerprint" => Checkout::CartFingerprint.digest(
+            cart: cart, postcode: resolved_postcode, discount_code: session[:discount_code]
+          ),
+          "postcode" => resolved_postcode,
+          "zone" => result.zone.to_s
+        }
+        redirect_to checkout_path, status: :see_other
+      else
+        redirect_to result.session.url, allow_other_host: true, status: :see_other
+      end
     rescue Stripe::StripeError => e
       session.delete(:discount_code) if builder&.invalid_discount?
       Rails.logger.error("Stripe error: #{e.message}")

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -105,6 +105,32 @@ class CheckoutsController < ApplicationController
     end
   end
 
+  # The on-site checkout page. Renders the Stripe session stashed by #create;
+  # performs no Stripe writes, so refresh and back-navigation are free.
+  def show
+    return redirect_to cart_path unless OnsiteCheckout.enabled?
+
+    stash = session[:onsite_checkout]
+    cart = Current.cart
+    return redirect_to cart_path if stash.blank? || cart.blank? || cart.cart_items.empty?
+
+    postcode = session[:delivery_postcode].presence || stash["postcode"]
+    fingerprint = Checkout::CartFingerprint.digest(
+      cart: cart, postcode: postcode, discount_code: session[:discount_code]
+    )
+    if fingerprint != stash["fingerprint"]
+      session.delete(:onsite_checkout)
+      return redirect_to cart_path, notice: "Your basket changed. Continue to payment when you're ready."
+    end
+
+    @client_secret = stash["client_secret"]
+    @priced_zone = stash["zone"]
+    @show_promo = session[:discount_code].blank? && !cart.only_samples?
+    @prefill_address = Current.user&.addresses&.find_by(id: session[:selected_address_id]) ||
+                       Current.user&.addresses&.default_first&.first
+    @customer_email = Current.user&.email_address
+  end
+
   def success
     session_id = params[:session_id]
 

--- a/app/controllers/shipping_zones_controller.rb
+++ b/app/controllers/shipping_zones_controller.rb
@@ -1,9 +1,12 @@
 # The zone guard's server half: resolves a postcode to its shipping zone so the
 # on-site checkout page can compare the address being typed against the zone
-# the order was priced for. Read-only, session-free, public — it exposes
-# nothing the delivery page doesn't already publish.
+# the order was priced for. Read-only and public; it exposes nothing the
+# delivery page doesn't already publish. Skips the storefront chrome (cart
+# resolution, nav queries): the route sits outside checkout's rate limit, so a
+# cookieless client hammering it must not mint an orphan Cart row per hit.
 class ShippingZonesController < ApplicationController
   allow_unauthenticated_access
+  skip_before_action :set_current_cart, :set_nav_categories
 
   def show
     zone = ShippingZone.for(params[:postcode])

--- a/app/controllers/shipping_zones_controller.rb
+++ b/app/controllers/shipping_zones_controller.rb
@@ -1,0 +1,12 @@
+# The zone guard's server half: resolves a postcode to its shipping zone so the
+# on-site checkout page can compare the address being typed against the zone
+# the order was priced for. Read-only, session-free, public — it exposes
+# nothing the delivery page doesn't already publish.
+class ShippingZonesController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    zone = ShippingZone.for(params[:postcode])
+    render json: { zone: zone, deliverable: ShippingZone.deliverable?(zone) }
+  end
+end

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -79,7 +79,7 @@ module Webhooks
       # needed so SessionAmounts can identify the shipping line by its metadata.
       full_session = Stripe::Checkout::Session.retrieve(
         id: session.id,
-        expand: [ "collected_information", "line_items.data.price.product" ]
+        expand: [ "collected_information", "line_items.data.price.product", "payment_intent.payment_method" ]
       )
 
       # Extract shipping address
@@ -254,7 +254,7 @@ module Webhooks
       Rails.event.notify("checkout.completed",
         order_id: order.id,
         total: order.total_amount.to_f,
-        payment_method: "card"
+        payment_method: Checkout::SessionDetails.payment_method_type(stripe_session)
       )
     end
   end

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -62,6 +62,7 @@ const lazyControllers = {
   "password-visibility": () => import("../javascript/controllers/password_visibility_controller"),
   "save-address-prompt": () => import("../javascript/controllers/save_address_prompt_controller"),
   "order-summary-toggle": () => import("../javascript/controllers/order_summary_toggle_controller"),
+  "onsite-checkout": () => import("../javascript/controllers/onsite_checkout_controller"),
   "title-preview": () => import("../javascript/controllers/title_preview_controller"),
   "field-sync": () => import("../javascript/controllers/field_sync_controller"),
   "delivery-countdown": () => import("../javascript/controllers/delivery_countdown_controller"),

--- a/app/frontend/javascript/controllers/onsite_checkout_controller.js
+++ b/app/frontend/javascript/controllers/onsite_checkout_controller.js
@@ -39,17 +39,38 @@ export default class extends Controller {
         clientSecret: this.clientSecretValue,
         defaultValues: this.defaultValues()
       })
-      this.actions = await this.checkout.loadActions()
+      // loadActions resolves to a {type, actions} result wrapper; the
+      // callable actions (updateEmail, confirm, ...) live one level down.
+      const loaded = await this.checkout.loadActions()
+      if (!loaded?.actions) throw new Error(`loadActions returned type ${loaded?.type}`)
+      this.actions = loaded.actions
     } catch (error) {
       console.error("[onsite-checkout] init failed:", error)
       return this.fatal()
     }
 
-    this.checkout.createPaymentElement().mount(this.paymentTarget)
-    this.checkout.createShippingAddressElement().mount(this.addressTarget)
+    // The awaits above straddle navigation: if the shopper already left the
+    // page, mounting into the departed DOM would leak live Stripe elements.
+    if (!this.element.isConnected) return
+
+    this.paymentElement = this.checkout.createPaymentElement()
+    this.paymentElement.mount(this.paymentTarget)
+    this.addressElement = this.checkout.createShippingAddressElement()
+    this.addressElement.mount(this.addressTarget)
 
     this.checkout.on("change", (session) => this.sessionChanged(session))
     this.sessionChanged(this.actions.getSession())
+  }
+
+  // The page is marked turbo-cache-control no-cache, so leaving always tears
+  // the controller down and Back re-renders server-side; drop timers and
+  // elements here so late SDK callbacks can't fire into the departed DOM.
+  disconnect() {
+    clearTimeout(this.zoneTimer)
+    this.paymentElement?.destroy?.()
+    this.addressElement?.destroy?.()
+    this.paymentElement = this.addressElement = null
+    this.checkout = this.actions = this.session = null
   }
 
   // Prefill for logged-in customers: the saved address #create synced to
@@ -66,6 +87,8 @@ export default class extends Controller {
   // --- session state → page ---
 
   sessionChanged(session) {
+    if (!this.element.isConnected) return // SDK callbacks can outlive the page
+
     this.renderTotals(session)
     this.guardZone(session)
     this.session = session
@@ -112,14 +135,22 @@ export default class extends Controller {
   }
 
   async checkZone(postcode) {
+    let zoneOk = true // fail open (incl. non-200): no worse than hosted checkout today
     try {
       const response = await fetch(`/shipping_zone?postcode=${encodeURIComponent(postcode)}`)
-      if (!response.ok) return
-      const { zone } = await response.json()
-      this.zoneOk = zone === this.pricedZoneValue
+      if (response.ok) {
+        const { zone } = await response.json()
+        zoneOk = zone === this.pricedZoneValue
+      }
     } catch {
-      this.zoneOk = true // fail open: no worse than hosted checkout today
+      // fail open
     }
+
+    // Only the latest postcode owns the verdict: a slow response for an
+    // earlier one must not overwrite it (last-response-wins race).
+    if (postcode !== this.lastCheckedPostcode) return
+
+    this.zoneOk = zoneOk
     this.zoneWarningTarget.classList.toggle("hidden", this.zoneOk)
     this.syncPayButton()
   }
@@ -131,8 +162,11 @@ export default class extends Controller {
     const email = this.emailTarget.value.trim()
     if (!email) return
     try {
-      await this.actions.updateEmail(email)
-    } catch {
+      const result = await this.actions.updateEmail(email)
+      if (result?.error) return this.showError(result.error.message || "Please check your email address.")
+      this.errorTarget.classList.add("hidden")
+    } catch (error) {
+      console.error("[onsite-checkout] updateEmail failed:", error)
       this.showError("Please check your email address.")
     }
   }
@@ -159,7 +193,8 @@ export default class extends Controller {
 
   async removePromo() {
     try {
-      await this.actions.removePromotionCode()
+      const result = await this.actions.removePromotionCode()
+      if (result?.error) throw result.error
     } catch (error) {
       console.error("[onsite-checkout] promo removal failed:", error)
       return
@@ -177,12 +212,19 @@ export default class extends Controller {
     this.payButtonTarget.disabled = true
     this.errorTarget.classList.add("hidden")
 
-    // On success Stripe redirects to return_url; we only come back on error.
-    const result = await this.actions.confirm()
-    if (result?.error) {
+    // On success Stripe redirects to return_url, so the button stays disabled;
+    // any other outcome (a reported error OR a rejection, e.g. a network drop
+    // mid-confirm) must surface a message and re-enable the button, or the
+    // shopper is stuck on a dead Pay button.
+    try {
+      const result = await this.actions.confirm()
+      if (!result?.error) return
       this.showError(result.error.message || "Payment failed. Please try again.")
-      this.syncPayButton()
+    } catch (error) {
+      console.error("[onsite-checkout] confirm failed:", error)
+      this.showError("Payment couldn't be completed. Please check your connection and try again.")
     }
+    this.syncPayButton()
   }
 
   // --- errors ---

--- a/app/frontend/javascript/controllers/onsite_checkout_controller.js
+++ b/app/frontend/javascript/controllers/onsite_checkout_controller.js
@@ -1,0 +1,198 @@
+import { Controller } from "@hotwired/stimulus"
+
+// On-site checkout: binds the page to a Stripe Checkout Session (ui_mode:
+// "custom") created server-side. Stripe's SDK owns the money math; this
+// controller mounts the secure elements, mirrors session totals into the
+// summary, applies/removes promo codes, guards the shipping zone, and
+// confirms. API per https://docs.stripe.com/js/custom_checkout.
+//
+// Money lines: only total, VAT, and discount re-render from the SDK. The goods
+// subtotal and shipping lines stay server-rendered on purpose - shipping rides
+// as a Stripe LINE ITEM (see Checkout::SessionBuilder), so the SDK's
+// session.total.subtotal INCLUDES shipping and would mislabel our goods-only
+// "Subtotal" row. Neither can change on-page in v1 (no cart editing, no
+// shipping choice); only a promo code moves money, and that moves exactly
+// discount, VAT, and total.
+export default class extends Controller {
+  static targets = [
+    "email", "address", "payment", "payButton", "error",
+    "totalLine", "discountRow", "zoneWarning",
+    "promoSection", "promoForm", "promoInput", "promoApplied", "promoCode", "promoError"
+  ]
+
+  static values = {
+    clientSecret: String,
+    publishableKey: String,
+    pricedZone: String,
+    guest: Boolean,
+    prefill: Object
+  }
+
+  async connect() {
+    this.zoneOk = true
+
+    if (!window.Stripe) return this.fatal()
+
+    try {
+      this.stripe = Stripe(this.publishableKeyValue)
+      this.checkout = await this.stripe.initCheckoutElementsSdk({
+        clientSecret: this.clientSecretValue,
+        defaultValues: this.defaultValues()
+      })
+      this.actions = await this.checkout.loadActions()
+    } catch (error) {
+      console.error("[onsite-checkout] init failed:", error)
+      return this.fatal()
+    }
+
+    this.checkout.createPaymentElement().mount(this.paymentTarget)
+    this.checkout.createShippingAddressElement().mount(this.addressTarget)
+
+    this.checkout.on("change", (session) => this.sessionChanged(session))
+    this.sessionChanged(this.actions.getSession())
+  }
+
+  // Prefill for logged-in customers: the saved address #create synced to
+  // Stripe, and nothing else (their email is already on the session via
+  // customer/customer_email). Guests start blank and type both.
+  defaultValues() {
+    const prefill = this.prefillValue || {}
+    if (!prefill.line1) return undefined
+
+    const { name, ...address } = prefill
+    return { shippingAddress: { name, address } }
+  }
+
+  // --- session state → page ---
+
+  sessionChanged(session) {
+    this.renderTotals(session)
+    this.guardZone(session)
+    this.session = session
+    this.syncPayButton()
+  }
+
+  renderTotals(session) {
+    // SDK amounts arrive pre-formatted (session.total.*.amount) in the
+    // session's currency; minorUnitsAmount backs the zero checks.
+    const total = session?.total
+    if (!total) return
+
+    if (total.total?.amount) this.totalLineTarget.textContent = total.total.amount
+    this.updateMoneyLine("vat", total.taxExclusive?.amount)
+
+    const discount = total.discount
+    const discountActive = (discount?.minorUnitsAmount || 0) > 0
+    if (discountActive) this.updateMoneyLine("discount", `-${discount.amount}`)
+    if (this.hasDiscountRowTarget) {
+      this.discountRowTarget.classList.toggle("hidden", !discountActive)
+      this.discountRowTarget.classList.toggle("flex", discountActive)
+    }
+  }
+
+  updateMoneyLine(kind, formattedAmount) {
+    if (!formattedAmount) return
+    const el = this.element.querySelector(`[data-onsite-checkout-money-kind='${kind}']`)
+    if (el) el.textContent = formattedAmount
+  }
+
+  syncPayButton() {
+    this.payButtonTarget.disabled = !this.zoneOk || this.session?.canConfirm === false
+  }
+
+  // --- zone guard (best-effort; any failure fails open) ---
+
+  guardZone(session) {
+    const postcode = session?.shippingAddress?.address?.postal_code
+    if (!postcode || postcode === this.lastCheckedPostcode) return
+
+    this.lastCheckedPostcode = postcode
+    clearTimeout(this.zoneTimer)
+    this.zoneTimer = setTimeout(() => this.checkZone(postcode), 400)
+  }
+
+  async checkZone(postcode) {
+    try {
+      const response = await fetch(`/shipping_zone?postcode=${encodeURIComponent(postcode)}`)
+      if (!response.ok) return
+      const { zone } = await response.json()
+      this.zoneOk = zone === this.pricedZoneValue
+    } catch {
+      this.zoneOk = true // fail open: no worse than hosted checkout today
+    }
+    this.zoneWarningTarget.classList.toggle("hidden", this.zoneOk)
+    this.syncPayButton()
+  }
+
+  // --- email (guests only; logged-in email is read-only and already on the session) ---
+
+  async emailChanged() {
+    if (!this.guestValue) return
+    const email = this.emailTarget.value.trim()
+    if (!email) return
+    try {
+      await this.actions.updateEmail(email)
+    } catch {
+      this.showError("Please check your email address.")
+    }
+  }
+
+  // --- promo codes ---
+
+  async applyPromo() {
+    const code = this.promoInputTarget.value.trim()
+    if (!code) return
+    this.promoErrorTarget.classList.add("hidden")
+    try {
+      const result = await this.actions.applyPromotionCode(code)
+      if (result?.error) throw result.error
+    } catch (error) {
+      this.promoErrorTarget.textContent = error?.message || "That code didn't work."
+      this.promoErrorTarget.classList.remove("hidden")
+      return
+    }
+    this.promoCodeTarget.textContent = code.toUpperCase()
+    this.promoFormTarget.classList.add("hidden")
+    this.promoAppliedTarget.classList.remove("hidden")
+    this.promoAppliedTarget.classList.add("flex")
+  }
+
+  async removePromo() {
+    try {
+      await this.actions.removePromotionCode()
+    } catch (error) {
+      console.error("[onsite-checkout] promo removal failed:", error)
+      return
+    }
+    this.promoAppliedTarget.classList.add("hidden")
+    this.promoAppliedTarget.classList.remove("flex")
+    this.promoFormTarget.classList.remove("hidden")
+    this.promoInputTarget.value = ""
+  }
+
+  // --- confirm ---
+
+  async pay() {
+    if (!this.zoneOk) return
+    this.payButtonTarget.disabled = true
+    this.errorTarget.classList.add("hidden")
+
+    // On success Stripe redirects to return_url; we only come back on error.
+    const result = await this.actions.confirm()
+    if (result?.error) {
+      this.showError(result.error.message || "Payment failed. Please try again.")
+      this.syncPayButton()
+    }
+  }
+
+  // --- errors ---
+
+  showError(message) {
+    this.errorTarget.textContent = message
+    this.errorTarget.classList.remove("hidden")
+  }
+
+  fatal() {
+    this.showError("Checkout couldn't load. Please refresh, or return to your basket and try again.")
+  }
+}

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -17,8 +17,8 @@ module CartsHelper
   # order_summary_lines). Delegates to CartSummary so the line order, labels, money
   # format and discount-visibility rule live in one place; each surface supplies its
   # own row markup. See CartSummary for the shape of each line.
-  def cart_summary_lines(cart)
-    CartSummary.lines(cart)
+  def cart_summary_lines(cart, placeholder_discount: false)
+    CartSummary.lines(cart, placeholder_discount: placeholder_discount)
   end
 
   # The DOM id for a cart-summary line's amount span on the cart page, kept stable

--- a/app/models/onsite_checkout.rb
+++ b/app/models/onsite_checkout.rb
@@ -1,0 +1,11 @@
+# Whether checkout renders on afida.com (Stripe custom UI) instead of
+# redirecting to Stripe's hosted page. Read from ENV on every call, not into a
+# constant, so flipping back to hosted is an env change + redeploy with no code
+# edit — the rollback lever the on-site checkout spec promises.
+class OnsiteCheckout
+  TRUTHY = %w[true 1].freeze
+
+  def self.enabled?
+    TRUTHY.include?(ENV["ONSITE_CHECKOUT"].to_s.strip.downcase)
+  end
+end

--- a/app/models/onsite_checkout.rb
+++ b/app/models/onsite_checkout.rb
@@ -1,11 +1,27 @@
 # Whether checkout renders on afida.com (Stripe custom UI) instead of
-# redirecting to Stripe's hosted page. Read from ENV on every call, not into a
-# constant, so flipping back to hosted is an env change + redeploy with no code
-# edit — the rollback lever the on-site checkout spec promises.
+# redirecting to Stripe's hosted page. Two levers:
+#
+# - The ONSITE_CHECKOUT env var, the global switch. Read from ENV on every
+#   call, not into a constant, so flipping back to hosted is an env change +
+#   redeploy with no code edit: the rollback lever the on-site checkout spec
+#   promises.
+# - A per-session preview flag, so the mode can be tested in production before
+#   the global switch is thrown: any URL with ?onsite_checkout=1 turns it on
+#   for that browser session, ?onsite_checkout=0 back off (captured by
+#   ApplicationController#capture_onsite_checkout_preview).
 class OnsiteCheckout
   TRUTHY = %w[true 1].freeze
+  PREVIEW_SESSION_KEY = "onsite_checkout_preview"
 
-  def self.enabled?
-    TRUTHY.include?(ENV["ONSITE_CHECKOUT"].to_s.strip.downcase)
+  def self.enabled?(session = nil)
+    truthy?(ENV["ONSITE_CHECKOUT"]) || preview?(session)
+  end
+
+  def self.preview?(session)
+    session ? session[PREVIEW_SESSION_KEY].present? : false
+  end
+
+  def self.truthy?(value)
+    TRUTHY.include?(value.to_s.strip.downcase)
   end
 end

--- a/app/models/shipping_zone.rb
+++ b/app/models/shipping_zone.rb
@@ -187,6 +187,14 @@ class ShippingZone
       ZONES.include?(zone)
     end
 
+    # The canonical form of a customer-typed postcode: uppercased, trimmed,
+    # internal runs of spaces collapsed. This is what .for matches against and
+    # what Checkout::CartFingerprint hashes, so "the same postcode" means the
+    # same thing to the zone resolver and to the staleness fingerprint.
+    def normalise(postcode)
+      postcode.to_s.upcase.strip.squeeze(" ")
+    end
+
     # Working days on top of the standard next-working-day dispatch.
     #
     # An undeliverable zone falls to the SLOWEST transit rather than 0. Defaulting
@@ -248,7 +256,7 @@ class ShippingZone
     # Accepts a full postcode (via Address::UK_POSTCODE_REGEX, so there is one
     # definition of a valid UK postcode) or an outward code alone.
     def parse(postcode)
-      normalised = postcode.to_s.upcase.strip
+      normalised = normalise(postcode)
       outward = outward_code(normalised)
       return nil unless outward
 

--- a/app/services/cart_summary.rb
+++ b/app/services/cart_summary.rb
@@ -27,12 +27,13 @@ class CartSummary
   # that no longer holds the answer.
   DEFERRED_LABEL = "Enter postcode"
 
-  def self.lines(cart)
-    new(cart).lines
+  def self.lines(cart, placeholder_discount: false)
+    new(cart, placeholder_discount: placeholder_discount).lines
   end
 
-  def initialize(cart)
+  def initialize(cart, placeholder_discount: false)
     @cart = cart
+    @placeholder_discount = placeholder_discount
   end
 
   def lines
@@ -40,7 +41,11 @@ class CartSummary
       line(:subtotal, "Subtotal", money(@cart.subtotal_amount)),
       line(:shipping, "Shipping", shipping_display)
     ]
-    result << discount_line if @cart.discount_amount.positive?
+    if @cart.discount_amount.positive?
+      result << discount_line
+    elsif @placeholder_discount
+      result << placeholder_discount_line
+    end
     result << line(:vat, "VAT (#{(VAT_RATE * 100).to_i}%)", money(@cart.vat_amount))
     result << line(:total, "Total", money(@cart.display_total_amount))
     result
@@ -59,6 +64,16 @@ class CartSummary
       amount: "-#{money(@cart.discount_amount)}",
       negative: true
     }
+  end
+
+  # An empty discount row in the discount line's canonical slot, marked
+  # placeholder so the requesting surface renders it hidden. The on-site
+  # checkout page asks for it: a promo code applied on-page creates a discount
+  # the server never rendered, and the page's JS needs a row to unhide without
+  # the view guessing where the discount slot sits. The cart surfaces never
+  # pass the option, so their line set is unchanged.
+  def placeholder_discount_line
+    { kind: :discount, label: "Discount", amount: nil, negative: true, placeholder: true }
   end
 
   # "Free" at/above the free-shipping threshold, the currency amount below it, and

--- a/app/services/checkout/cart_fingerprint.rb
+++ b/app/services/checkout/cart_fingerprint.rb
@@ -1,0 +1,19 @@
+module Checkout
+  # Staleness fingerprint for a stashed on-site checkout session. The Stripe
+  # session freezes line items and shipping price at #create; if the inputs
+  # that produced them change before the GET page renders (cart edited in
+  # another tab, postcode retyped, discount claimed), the stash must be
+  # discarded rather than charged. Same inputs ⇒ same digest.
+  class CartFingerprint
+    def self.digest(cart:, postcode:, discount_code:)
+      payload = {
+        items: cart.cart_items.order(:id).map do |item|
+          [ item.id, item.product_id, item.quantity, item.price.to_s, item.sample?, item.configuration ]
+        end,
+        postcode: postcode.to_s.upcase.strip.squeeze(" "),
+        discount_code: discount_code.to_s
+      }
+      Digest::SHA256.hexdigest(payload.to_json)
+    end
+  end
+end

--- a/app/services/checkout/cart_fingerprint.rb
+++ b/app/services/checkout/cart_fingerprint.rb
@@ -10,7 +10,7 @@ module Checkout
         items: cart.cart_items.order(:id).map do |item|
           [ item.id, item.product_id, item.quantity, item.price.to_s, item.sample?, item.configuration ]
         end,
-        postcode: postcode.to_s.upcase.strip.squeeze(" "),
+        postcode: ShippingZone.normalise(postcode),
         discount_code: discount_code.to_s
       }
       Digest::SHA256.hexdigest(payload.to_json)

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -1,12 +1,12 @@
 module Checkout
   class SessionBuilder
-    Result = Struct.new(:session, :invalid_discount_code, :selected_address_id, keyword_init: true) do
+    Result = Struct.new(:session, :invalid_discount_code, :selected_address_id, :zone, keyword_init: true) do
       def invalid_discount?
         invalid_discount_code.present?
       end
     end
 
-    def initialize(cart:, user:, address_id:, discount_code:, datafast_visitor_id:, datafast_session_id:, success_url:, cancel_url:, delivery_postcode: nil)
+    def initialize(cart:, user:, address_id:, discount_code:, datafast_visitor_id:, datafast_session_id:, success_url:, cancel_url:, delivery_postcode: nil, ui_mode: :hosted, return_url: nil)
       @cart = cart
       @user = user
       @address_id = address_id
@@ -16,6 +16,8 @@ module Checkout
       @datafast_session_id = datafast_session_id
       @success_url = success_url
       @cancel_url = cancel_url
+      @ui_mode = ui_mode
+      @return_url = return_url
     end
 
     # Mirrors Result#invalid_discount? so the controller can clean up session
@@ -32,25 +34,24 @@ module Checkout
       Result.new(
         session: Stripe::Checkout::Session.create(session_params),
         invalid_discount_code: invalid_discount_code,
-        selected_address_id: selected_address_id
+        selected_address_id: selected_address_id,
+        zone: zone
       )
     end
 
     private
 
     attr_reader :cart, :user, :address_id, :discount_code, :delivery_postcode, :datafast_visitor_id,
-                :datafast_session_id, :success_url, :cancel_url, :invalid_discount_code, :selected_address_id
+                :datafast_session_id, :success_url, :cancel_url, :invalid_discount_code, :selected_address_id,
+                :ui_mode, :return_url
 
     def build_session_params
       {
-        payment_method_types: [ "card" ],
         line_items: line_items,
         mode: "payment",
         shipping_address_collection: {
           allowed_countries: Shipping::ALLOWED_COUNTRIES
         },
-        success_url: success_url,
-        cancel_url: cancel_url,
         metadata: {
           cart_id: cart.id.to_s,
           discount_code: discount_code,
@@ -62,7 +63,26 @@ module Checkout
           # rather than re-deriving from the delivered-to postcode.
           shipping_zone: zone.to_s
         }
-      }
+      }.merge(mode_params)
+    end
+
+    # The ONLY params allowed to differ between hosted and custom mode. The
+    # custom (on-site) page shows wallets and Link inside the Payment Element;
+    # hosted stays card-only exactly as it always was.
+    def mode_params
+      if ui_mode == :custom
+        {
+          ui_mode: "custom",
+          return_url: return_url,
+          payment_method_types: [ "card", "link" ]
+        }
+      else
+        {
+          payment_method_types: [ "card" ],
+          success_url: success_url,
+          cancel_url: cancel_url
+        }
+      end
     end
 
     # Product line items plus, unless shipping is free, the taxed shipping line.

--- a/app/services/checkout/session_details.rb
+++ b/app/services/checkout/session_details.rb
@@ -50,6 +50,19 @@ module Checkout
       zone if ShippingZone.deliverable?(zone.to_sym)
     end
 
+    # The type of the payment method that actually paid the session ("card",
+    # "link", ...), read from the expanded payment_intent; callers must
+    # retrieve the session with expand: ["payment_intent.payment_method"].
+    # The session's payment_method_types is the CONFIGURED list, not the
+    # customer's choice: custom mode configures ["card", "link"], so its first
+    # entry says nothing about how the customer paid. Falls back to "card"
+    # when no expanded intent is present (a zero-total no_payment_required
+    # session has no payment at all, and an unexpanded retrieve returns an id
+    # string), matching what the event recorded before the type was read.
+    def payment_method_type(session)
+      session.try(:payment_intent).try(:payment_method).try(:type) || "card"
+    end
+
     # The Stripe-entered promotion code (the human-typed string, e.g. "SUMMER20"), or
     # nil when none was applied. Deliberately does NOT rescue an unexpected Stripe
     # shape: each caller owns that policy. OrderCreator lets a NoMethodError surface

--- a/app/views/checkouts/_summary.html.erb
+++ b/app/views/checkouts/_summary.html.erb
@@ -1,0 +1,23 @@
+<%# On-site checkout order summary. Lines come from cart_summary_lines (the same
+    source the cart page uses) for the initial server render; the money values
+    carry data attributes so the onsite-checkout Stimulus controller re-renders
+    them from the Stripe session state (the charging authority) once the SDK is
+    live. Line KINDS map to attributes; keep the kinds in step with CartSummary.
+    Deliberately NOT the #cart_summary id — the cart page's Turbo Streams own it. %>
+<div id="checkout_summary">
+  <h2 class="text-lg sm:text-2xl mb-3 sm:mb-6">Order Summary</h2>
+
+  <% cart_summary_lines(cart).each do |line| %>
+    <% if line[:kind] == :total %>
+      <div class="flex justify-between text-lg sm:text-xl text-gray-800 border-t pt-3 mt-3">
+        <span><%= line[:label] %></span>
+        <span data-onsite-checkout-target="totalLine"><%= line[:amount] %></span>
+      </div>
+    <% else %>
+      <div class="flex justify-between mb-2 text-sm sm:text-base <%= line[:negative] ? "text-success" : "text-gray-700" %>">
+        <span><%= line[:label] %></span>
+        <span data-onsite-checkout-money-kind="<%= line[:kind] %>"><%= line[:amount] %></span>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/checkouts/_summary.html.erb
+++ b/app/views/checkouts/_summary.html.erb
@@ -3,30 +3,26 @@
     carry data attributes so the onsite-checkout Stimulus controller re-renders
     them from the Stripe session state (the charging authority) once the SDK is
     live. Line KINDS map to attributes; keep the kinds in step with CartSummary.
-    Deliberately NOT the #cart_summary id — the cart page's Turbo Streams own it. %>
+    placeholder_discount asks CartSummary for a hidden discount row when none is
+    taken, so a promo code applied on-page has a row for the JS to unhide.
+    Deliberately NOT the #cart_summary id: the cart page's Turbo Streams own it. %>
 <div id="checkout_summary">
   <h2 class="text-lg sm:text-2xl mb-3 sm:mb-6">Order Summary</h2>
 
-  <% lines = cart_summary_lines(cart) %>
-  <% has_discount = lines.any? { |line| line[:kind] == :discount } %>
-  <% lines.each do |line| %>
-    <% if line[:kind] == :vat && !has_discount %>
-      <%# Hidden placeholder: a promo code applied on-page creates a discount
-          the server never rendered; the Stimulus controller unhides this row
-          and fills it from the Stripe session. %>
-      <div class="hidden justify-between mb-2 text-sm sm:text-base text-success"
-           data-onsite-checkout-target="discountRow">
-        <span>Discount</span>
-        <span data-onsite-checkout-money-kind="discount"></span>
-      </div>
-    <% end %>
+  <% cart_summary_lines(cart, placeholder_discount: true).each do |line| %>
     <% if line[:kind] == :total %>
       <div class="flex justify-between text-lg sm:text-xl text-gray-800 border-t pt-3 mt-3">
         <span><%= line[:label] %></span>
         <span data-onsite-checkout-target="totalLine"><%= line[:amount] %></span>
       </div>
+    <% elsif line[:kind] == :discount %>
+      <div class="<%= line[:placeholder] ? "hidden" : "flex" %> justify-between mb-2 text-sm sm:text-base text-success"
+           data-onsite-checkout-target="discountRow">
+        <span><%= line[:label] %></span>
+        <span data-onsite-checkout-money-kind="discount"><%= line[:amount] %></span>
+      </div>
     <% else %>
-      <div class="flex justify-between mb-2 text-sm sm:text-base <%= line[:negative] ? "text-success" : "text-gray-700" %>">
+      <div class="flex justify-between mb-2 text-sm sm:text-base text-gray-700">
         <span><%= line[:label] %></span>
         <span data-onsite-checkout-money-kind="<%= line[:kind] %>"><%= line[:amount] %></span>
       </div>

--- a/app/views/checkouts/_summary.html.erb
+++ b/app/views/checkouts/_summary.html.erb
@@ -7,7 +7,19 @@
 <div id="checkout_summary">
   <h2 class="text-lg sm:text-2xl mb-3 sm:mb-6">Order Summary</h2>
 
-  <% cart_summary_lines(cart).each do |line| %>
+  <% lines = cart_summary_lines(cart) %>
+  <% has_discount = lines.any? { |line| line[:kind] == :discount } %>
+  <% lines.each do |line| %>
+    <% if line[:kind] == :vat && !has_discount %>
+      <%# Hidden placeholder: a promo code applied on-page creates a discount
+          the server never rendered; the Stimulus controller unhides this row
+          and fills it from the Stripe session. %>
+      <div class="hidden justify-between mb-2 text-sm sm:text-base text-success"
+           data-onsite-checkout-target="discountRow">
+        <span>Discount</span>
+        <span data-onsite-checkout-money-kind="discount"></span>
+      </div>
+    <% end %>
     <% if line[:kind] == :total %>
       <div class="flex justify-between text-lg sm:text-xl text-gray-800 border-t pt-3 mt-3">
         <span><%= line[:label] %></span>

--- a/app/views/checkouts/show.html.erb
+++ b/app/views/checkouts/show.html.erb
@@ -1,0 +1,95 @@
+<% content_for :title, "Checkout | Afida" %>
+<% content_for :head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
+<div class="max-w-6xl mx-auto px-4 py-8"
+     data-controller="onsite-checkout"
+     data-onsite-checkout-client-secret-value="<%= @client_secret %>"
+     data-onsite-checkout-publishable-key-value="<%= Rails.configuration.stripe[:publishable_key] %>"
+     data-onsite-checkout-priced-zone-value="<%= @priced_zone %>"
+     data-onsite-checkout-guest-value="<%= Current.user.blank? %>"
+     data-onsite-checkout-prefill-value="<%= {
+       name: @prefill_address&.recipient_name,
+       line1: @prefill_address&.line1,
+       line2: @prefill_address&.line2,
+       city: @prefill_address&.city,
+       postal_code: @prefill_address&.postcode,
+       country: "GB"
+     }.compact.to_json %>">
+
+  <h1 class="text-2xl sm:text-3xl mb-6">Checkout</h1>
+
+  <div class="flex flex-col-reverse md:flex-row gap-8">
+    <div class="w-full md:w-3/5 space-y-6">
+
+      <section>
+        <h2 class="text-lg mb-2">Contact</h2>
+        <% if @customer_email %>
+          <input type="email" value="<%= @customer_email %>" readonly
+                 class="input input-bordered w-full bg-gray-100"
+                 data-onsite-checkout-target="email">
+        <% else %>
+          <input type="email" placeholder="you@example.com" autocomplete="email"
+                 class="input input-bordered w-full"
+                 data-onsite-checkout-target="email"
+                 data-action="blur->onsite-checkout#emailChanged">
+        <% end %>
+      </section>
+
+      <section>
+        <h2 class="text-lg mb-2">Delivery address</h2>
+        <div data-onsite-checkout-target="address"></div>
+        <p class="text-sm text-error mt-2 hidden" data-onsite-checkout-target="zoneWarning">
+          This postcode is in a different delivery zone than your order was priced for.
+          <%= link_to "Return to your basket", cart_path, class: "link" %> to update your
+          delivery postcode and reprice.
+        </p>
+      </section>
+
+      <% if @show_promo %>
+        <section data-onsite-checkout-target="promoSection">
+          <h2 class="text-lg mb-2">Promo code</h2>
+          <div class="flex gap-2" data-onsite-checkout-target="promoForm">
+            <input type="text" placeholder="Enter code" class="input input-bordered input-sm flex-1"
+                   data-onsite-checkout-target="promoInput">
+            <button type="button" class="btn btn-sm btn-outline"
+                    data-action="onsite-checkout#applyPromo">Apply</button>
+          </div>
+          <div class="hidden items-center gap-2" data-onsite-checkout-target="promoApplied">
+            <span class="badge badge-success" data-onsite-checkout-target="promoCode"></span>
+            <button type="button" class="btn btn-xs btn-ghost"
+                    data-action="onsite-checkout#removePromo" aria-label="Remove promo code">&times;</button>
+          </div>
+          <p class="text-xs text-error mt-1 hidden" data-onsite-checkout-target="promoError"></p>
+        </section>
+      <% end %>
+
+      <section>
+        <h2 class="text-lg mb-2">Payment</h2>
+        <div data-onsite-checkout-target="payment"></div>
+      </section>
+
+      <p class="text-sm text-error hidden" data-onsite-checkout-target="error"></p>
+
+      <button type="button" class="btn btn-primary w-full" disabled
+              data-onsite-checkout-target="payButton"
+              data-action="onsite-checkout#pay">
+        Pay now
+      </button>
+
+      <noscript>
+        <p class="text-sm text-error">
+          Checkout needs JavaScript. <%= link_to "Return to your basket", cart_path, class: "link" %>.
+        </p>
+      </noscript>
+    </div>
+
+    <div class="w-full md:w-2/5">
+      <div class="bg-gray-100 p-4 sm:p-6 rounded-lg shadow-md">
+        <%= render "checkouts/summary", cart: Current.cart %>
+        <p class="mt-4 text-sm"><%= link_to "← Back to basket", cart_path, class: "link" %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/checkouts/show.html.erb
+++ b/app/views/checkouts/show.html.erb
@@ -1,6 +1,13 @@
 <% content_for :title, "Checkout | Afida" %>
 <% content_for :head do %>
-  <script src="https://js.stripe.com/v3/"></script>
+  <%# The VERSIONED bundle, matching the clover API version the stripe gem
+      pins: the legacy /v3/ bundle refuses initCheckoutElementsSdk with
+      "You must upgrade to the Basil release or higher". %>
+  <script src="https://js.stripe.com/clover/stripe.js"></script>
+  <%# Never snapshot this page: a Turbo cache restore would clone the Stripe
+      iframes as dead markup and re-run connect() against them. Back/forward
+      re-renders server-side instead, which #show serves for free. %>
+  <meta name="turbo-cache-control" content="no-cache">
 <% end %>
 
 <div class="max-w-6xl mx-auto px-4 py-8"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,10 +16,12 @@ Rails.application.configure do
 
     # GTM requires unsafe-inline and unsafe-eval for its dynamically injected tags.
     # The external domains cover GTM itself, Google Analytics, Google Ads,
-    # DataFast analytics, Google Customer Reviews, and the Cloudflare challenge platform.
+    # DataFast analytics, Google Customer Reviews, the Cloudflare challenge
+    # platform, and Stripe.js (the on-site checkout page).
     policy.script_src :self,
                       :unsafe_inline,
                       :unsafe_eval,
+                      "https://js.stripe.com",
                       "https://www.googletagmanager.com",
                       "https://www.google-analytics.com",
                       "https://www.googleadservices.com",
@@ -32,6 +34,7 @@ Rails.application.configure do
 
     # connect-src: where JS can send requests (fetch, XHR, WebSocket)
     policy.connect_src :self,
+                       "https://api.stripe.com",
                        "https://www.google-analytics.com",
                        "https://analytics.google.com",
                        "https://www.googletagmanager.com",
@@ -40,8 +43,11 @@ Rails.application.configure do
                        "https://datafa.st",
                        "https://*.sentry.io"
 
-    # frame-src: GTM noscript iframe and Google Customer Reviews
+    # frame-src: GTM noscript iframe, Google Customer Reviews, and Stripe
+    # Elements iframes (on-site checkout)
     policy.frame_src :self,
+                     "https://js.stripe.com",
+                     "https://hooks.stripe.com",
                      "https://www.googletagmanager.com",
                      "https://td.doubleclick.net",
                      "https://apis.google.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,10 @@ Rails.application.routes.draw do
     get :cancel, on: :collection
   end
 
+  # Read-only postcode→zone lookup for the on-site checkout's zone guard.
+  # Deliberately outside checkout's rate limit: it fires on address keystrokes.
+  resource :shipping_zone, only: [ :show ]
+
   resources :orders, only: [ :show, :index ] do
     member do
       get :confirmation

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+description: Codebase orientation for developers, covering data models, cart and checkout flows, authentication, and common tasks.
+status: active
+timestamp: 2026-07-29
+---
+
 # Developer Guide
 
 This guide provides technical documentation for developers working on the Afida e-commerce application.
@@ -282,22 +289,27 @@ end
 ## Checkout & Orders
 
 Two checkout modes share one session builder. Which one a customer gets is
-decided by the `ONSITE_CHECKOUT` env flag (`OnsiteCheckout.enabled?`, read
-live on every call):
+decided by `OnsiteCheckout.enabled?(session)`: the `ONSITE_CHECKOUT` env flag
+(read live on every call) is the global switch, and a per-session preview flag
+lets you test the on-site mode in production before flipping it globally. Visit
+any URL with `?onsite_checkout=1` to turn the preview on for your browser
+session, `?onsite_checkout=0` to turn it back off (captured by
+`ApplicationController#capture_onsite_checkout_preview`).
 
 - **Hosted** (flag off): `CheckoutsController#create` builds a Checkout
-  Session and redirects to `session.url` — Stripe's page collects everything.
+  Session and redirects to `session.url`; Stripe's page collects everything.
 - **On-site** (flag on): the same `#create` builds the session with
-  `ui_mode: "custom"`, stashes `{session_id, client_secret, fingerprint,
-  postcode, zone}` in the Rails session, and 303-redirects to `GET /checkout`,
+  `ui_mode: "custom"`, stashes `{client_secret, fingerprint, zone,
+  created_at}` in the Rails session, and 303-redirects to `GET /checkout`,
   which renders the checkout page on afida.com. Stripe.js's checkout SDK
   (`app/frontend/javascript/controllers/onsite_checkout_controller.js`) binds
   the page to the session: Payment Element + Shipping Address Element, promo
   codes via `applyPromotionCode`, and a zone guard that compares the typed
   postcode's zone (via `GET /shipping_zone`) against the zone the order was
   priced for. `Checkout::CartFingerprint` invalidates the stash if the cart,
-  postcode, or discount changed since `#create`; a stale stash bounces to the
-  cart. See `docs/superpowers/specs/2026-07-28-onsite-checkout-design.md` and
+  postcode, or discount changed since `#create`; a stale or expired stash
+  (Stripe sessions die at 24h) bounces to the cart.
+  See `docs/superpowers/specs/2026-07-28-onsite-checkout-design.md` and
   `docs/adr/0001-onsite-checkout-on-checkout-sessions.md`.
 
 ### Session creation (`Checkout::SessionBuilder`)
@@ -308,7 +320,7 @@ All money math lives in the Stripe session, built by
 - **Line items** carry the products AND the delivery charge. Shipping rides as
   a taxed line item (not a `shipping_option`) so manual tax rates apply VAT to
   it; it is prepended so it lands in Stripe's first `line_items` page.
-- **Shipping price** comes from `ShippingZone.for(delivery_postcode)` — the
+- **Shipping price** comes from `ShippingZone.for(delivery_postcode)`: the
   postcode captured on the cart page, resolved typed-field-first
   (`CheckoutsController#delivery_postcode_for`). `#create` refuses to build a
   session for an unknown or undeliverable destination. The priced zone is
@@ -329,13 +341,14 @@ All money math lives in the Stripe session, built by
 
 Both modes land on the same success URL with `?session_id=`:
 `CheckoutsController#success` retrieves the session (expanding
-`collected_information` and `line_items.data.price.product`), guards against
+`collected_information`, `line_items.data.price.product`, and
+`payment_intent.payment_method`), guards against
 the webhook's duplicate order, creates the order via `Checkout::OrderCreator`,
 clears the cart, and sends confirmation emails plus the Telegram notification.
 The `checkout.session.completed` webhook
 (`app/controllers/webhooks/stripe_controller.rb`) is the fallback that creates
 the order if the redirect never arrives. Zero-total orders complete with
-`payment_status: "no_payment_required"` — every completion gate accepts both
+`payment_status: "no_payment_required"`; every completion gate accepts both
 statuses via `Checkout::COMPLETED_PAYMENT_STATUSES`.
 
 ## Authentication

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -281,84 +281,62 @@ end
 
 ## Checkout & Orders
 
-### Stripe Checkout Flow
+Two checkout modes share one session builder. Which one a customer gets is
+decided by the `ONSITE_CHECKOUT` env flag (`OnsiteCheckout.enabled?`, read
+live on every call):
 
-**1. Create Checkout Session** (`CheckoutsController#create`):
-```ruby
-cart = Current.cart
+- **Hosted** (flag off): `CheckoutsController#create` builds a Checkout
+  Session and redirects to `session.url` — Stripe's page collects everything.
+- **On-site** (flag on): the same `#create` builds the session with
+  `ui_mode: "custom"`, stashes `{session_id, client_secret, fingerprint,
+  postcode, zone}` in the Rails session, and 303-redirects to `GET /checkout`,
+  which renders the checkout page on afida.com. Stripe.js's checkout SDK
+  (`app/frontend/javascript/controllers/onsite_checkout_controller.js`) binds
+  the page to the session: Payment Element + Shipping Address Element, promo
+  codes via `applyPromotionCode`, and a zone guard that compares the typed
+  postcode's zone (via `GET /shipping_zone`) against the zone the order was
+  priced for. `Checkout::CartFingerprint` invalidates the stash if the cart,
+  postcode, or discount changed since `#create`; a stale stash bounces to the
+  cart. See `docs/superpowers/specs/2026-07-28-onsite-checkout-design.md` and
+  `docs/adr/0001-onsite-checkout-on-checkout-sessions.md`.
 
-# Build line items from cart
-line_items = cart.cart_items.map do |item|
-  {
-    quantity: item.quantity,
-    price_data: {
-      currency: "gbp",
-      product_data: { name: item.product_variant.display_name },
-      unit_amount: (item.price * 100).round, # Stripe uses cents
-      tax_behavior: "exclusive"
-    },
-    tax_rates: [tax_rate.id] # 20% UK VAT
-  }
-end
+### Session creation (`Checkout::SessionBuilder`)
 
-# Create Stripe session
-session = Stripe::Checkout::Session.create(
-  payment_method_types: ["card"],
-  line_items: line_items,
-  mode: "payment",
-  shipping_address_collection: { allowed_countries: ["GB"] },
-  shipping_options: [
-    # Standard shipping: £4.99
-    # Express shipping: £9.99
-  ],
-  success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
-  cancel_url: cancel_checkout_url
-)
+All money math lives in the Stripe session, built by
+`app/services/checkout/session_builder.rb`:
 
-redirect_to session.url
-```
+- **Line items** carry the products AND the delivery charge. Shipping rides as
+  a taxed line item (not a `shipping_option`) so manual tax rates apply VAT to
+  it; it is prepended so it lands in Stripe's first `line_items` page.
+- **Shipping price** comes from `ShippingZone.for(delivery_postcode)` — the
+  postcode captured on the cart page, resolved typed-field-first
+  (`CheckoutsController#delivery_postcode_for`). `#create` refuses to build a
+  session for an unknown or undeliverable destination. The priced zone is
+  recorded in `metadata.shipping_zone`.
+- **Discounts**: a session-carried welcome coupon id is resolved to its
+  promotion code and applied via `discounts:`; with no code,
+  `allow_promotion_codes` lets the customer type one (on Stripe's page in
+  hosted mode, in the on-site promo control in custom mode). Samples-only
+  carts refuse all discounts. An invalid coupon falls back to
+  `allow_promotion_codes` and is reported via `Result#invalid_discount?`.
+- **Mode params** (`ui_mode`/`return_url` vs `success_url`/`cancel_url`, and
+  payment method types: hosted is card-only, custom adds Link with wallets
+  inside the Payment Element) are isolated in `SessionBuilder#mode_params`;
+  everything else is shared by construction. The parity test in
+  `test/services/checkout/session_builder_test.rb` pins this.
 
-**2. Handle Success** (`CheckoutsController#success`):
-```ruby
-# Retrieve Stripe session
-stripe_session = Stripe::Checkout::Session.retrieve(params[:session_id])
+### After payment
 
-# Check if order already exists (prevent duplicates)
-return if Order.exists?(stripe_session_id: stripe_session.id)
-
-# Create order from cart
-order = Order.create!(
-  user: Current.user,
-  email: stripe_session.customer_details.email,
-  stripe_session_id: stripe_session.id,
-  status: "paid",
-  subtotal_amount: cart.subtotal_amount,
-  vat_amount: cart.vat_amount,
-  shipping_amount: (stripe_session.shipping_cost.amount_total / 100.0),
-  total_amount: ...,
-  shipping_name: stripe_session.customer_details.name,
-  shipping_address_line1: stripe_session.customer_details.address.line1,
-  # ... other shipping fields
-)
-
-# Create order items
-cart.cart_items.each do |cart_item|
-  order.order_items.create!(
-    product_variant: cart_item.product_variant,
-    product_name: cart_item.product_variant.display_name,
-    product_sku: cart_item.product_variant.sku,
-    price: cart_item.price,
-    quantity: cart_item.quantity,
-    line_total: cart_item.subtotal_amount
-  )
-end
-
-# Clear cart
-cart.cart_items.destroy_all
-
-# Send confirmation email
-OrderMailer.with(order: order).confirmation_email.deliver_later
-```
+Both modes land on the same success URL with `?session_id=`:
+`CheckoutsController#success` retrieves the session (expanding
+`collected_information` and `line_items.data.price.product`), guards against
+the webhook's duplicate order, creates the order via `Checkout::OrderCreator`,
+clears the cart, and sends confirmation emails plus the Telegram notification.
+The `checkout.session.completed` webhook
+(`app/controllers/webhooks/stripe_controller.rb`) is the fallback that creates
+the order if the redirect never arrives. Zero-total orders complete with
+`payment_status: "no_payment_required"` — every completion gate accepts both
+statuses via `Checkout::COMPLETED_PAYMENT_STATUSES`.
 
 ## Authentication
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,13 @@
 # Update Log
 
+## 2026-07-29
+
+* **Update**: [Developer Guide](/developer_guide.md) checkout section: the mode decision is now `OnsiteCheckout.enabled?(session)`, adding a session-sticky production preview (`?onsite_checkout=1` on any URL, `=0` to clear) alongside the global `ONSITE_CHECKOUT` env flag (`onsite-checkout` branch, PR #271).
+
+## 2026-07-28
+
+* **Update**: [On-Site Checkout Plan](/superpowers/plans/2026-07-28-onsite-checkout.md) and the [Developer Guide](/developer_guide.md) gained OKF frontmatter (code-review follow-up on the `onsite-checkout` branch, PR #271). The guide's checkout section, rewritten on that branch for the two checkout modes and shipping zones, was corrected for the review fixes: leaner on-site session stash with a 23 h expiry, `payment_intent.payment_method` expansion so `checkout.completed` records the real payment method, and the destination re-resolved on `GET /checkout` instead of trusting the stash.
+
 ## 2026-07-08
 
 * **Creation**: Adopted OKF v0.1 for `docs/` (Phase 1). Added bundle conventions to repo `CLAUDE.md`, created this log, the root [index](/index.md), and the [SEO index](/seo/index.md).

--- a/docs/superpowers/plans/2026-07-28-onsite-checkout.md
+++ b/docs/superpowers/plans/2026-07-28-onsite-checkout.md
@@ -47,7 +47,7 @@
 
 The flag must read ENV **at call time** (no constant memoization) so ops can flip it with an env change + redeploy and tests can stub it.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ruby
 # test/models/onsite_checkout_test.rb
@@ -75,12 +75,12 @@ class OnsiteCheckoutTest < ActiveSupport::TestCase
 end
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bin/rails test test/models/onsite_checkout_test.rb`
 Expected: FAIL / error with `NameError: uninitialized constant OnsiteCheckout`
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```ruby
 # app/models/onsite_checkout.rb
@@ -98,12 +98,12 @@ class OnsiteCheckout
 end
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bin/rails test test/models/onsite_checkout_test.rb`
 Expected: PASS (3 runs, 0 failures)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add app/models/onsite_checkout.rb test/models/onsite_checkout_test.rb
@@ -122,7 +122,7 @@ Custom mode differs from hosted in EXACTLY three ways: `ui_mode: "custom"` + `re
 
 The existing test file's helpers (`build_session`, `build_stripe_session`, `stub_stripe_tax_rate_list`) are the idiom; read its first ~60 lines before starting.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `test/services/checkout/session_builder_test.rb` (inside the existing class, reusing its `setup`):
 
@@ -204,12 +204,12 @@ Add to `test/services/checkout/session_builder_test.rb` (inside the existing cla
 
 Note on `build_session`: the existing helper takes kwargs like `discount_code:`/`delivery_postcode:` and forwards to `Checkout::SessionBuilder.new`. Extend its signature to also forward `ui_mode:` and `return_url:` (defaulting so every existing call is untouched).
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `bin/rails test test/services/checkout/session_builder_test.rb`
 Expected: new tests FAIL (`unknown keyword: :ui_mode` and `NoMethodError: undefined method 'zone'`); ALL existing tests still PASS.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `app/services/checkout/session_builder.rb`:
 
@@ -296,17 +296,17 @@ Constructor — add the two keywords (hosted default keeps every existing caller
 
 Add `:ui_mode, :return_url` to the private `attr_reader` list.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `bin/rails test test/services/checkout/session_builder_test.rb`
 Expected: PASS, including all pre-existing tests.
 
-- [ ] **Step 5: Run the controller tests too** (they drive the builder through `#create`)
+- [x] **Step 5: Run the controller tests too** (they drive the builder through `#create`)
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
 Expected: PASS unchanged.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add app/services/checkout/session_builder.rb test/services/checkout/session_builder_test.rb
@@ -322,7 +322,7 @@ git commit -m "Teach SessionBuilder a custom ui_mode sharing all core params"
 - Modify: `config/routes.rb`
 - Test: `test/controllers/shipping_zones_controller_test.rb`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ruby
 # test/controllers/shipping_zones_controller_test.rb
@@ -362,12 +362,12 @@ class ShippingZonesControllerTest < ActionDispatch::IntegrationTest
 end
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bin/rails test test/controllers/shipping_zones_controller_test.rb`
 Expected: FAIL with `NameError: undefined local variable or method 'shipping_zone_path'`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `config/routes.rb`, next to `resource :checkout`:
 
@@ -396,12 +396,12 @@ end
 
 (If `allow_unauthenticated_access` is not how public controllers opt out in this app, mirror whatever `CheckoutsController` does — it has `allow_unauthenticated_access` at the top.)
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bin/rails test test/controllers/shipping_zones_controller_test.rb`
 Expected: PASS (5 runs)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add app/controllers/shipping_zones_controller.rb config/routes.rb test/controllers/shipping_zones_controller_test.rb
@@ -418,7 +418,7 @@ git commit -m "Add read-only shipping-zone lookup endpoint for the zone guard"
 
 The staleness fingerprint: same cart items + same postcode + same discount code ⇒ same digest. Any input change ⇒ different digest.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ruby
 # test/services/checkout/cart_fingerprint_test.rb
@@ -464,12 +464,12 @@ class Checkout::CartFingerprintTest < ActiveSupport::TestCase
 end
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bin/rails test test/services/checkout/cart_fingerprint_test.rb`
 Expected: FAIL with `NameError: uninitialized constant Checkout::CartFingerprint`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```ruby
 # app/services/checkout/cart_fingerprint.rb
@@ -496,12 +496,12 @@ end
 
 (If `item.sample?` or `item.configuration` doesn't exist on CartItem, check the model — `SessionBuilder#stripe_quantity` calls `item.sample?` and `item.configured?`/`item.configuration["size"]`, so both exist.)
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bin/rails test test/services/checkout/cart_fingerprint_test.rb`
 Expected: PASS (6 runs)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add app/services/checkout/cart_fingerprint.rb test/services/checkout/cart_fingerprint_test.rb
@@ -518,7 +518,7 @@ git commit -m "Add cart fingerprint for on-site checkout staleness checks"
 
 Flag off: byte-for-byte today's behaviour. Flag on: same guards and events, builder in custom mode, stash `{session_id, client_secret, fingerprint, postcode, zone}` under `session[:onsite_checkout]`, 303 to `checkout_path`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add to `test/controllers/checkouts_controller_test.rb`. The custom-mode Stripe session stub needs a `client_secret`; check `test/support/stripe_test_helper.rb` for `build_stripe_session` — if it doesn't accept overrides, add alongside it:
 
@@ -614,12 +614,12 @@ Use the `OnsiteCheckout.stubs` form. The flag class has its own ENV tests (Task 
   end
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
 Expected: the four new tests FAIL (flag-on posts still redirect to checkout.stripe.com; no stash). All existing tests PASS.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `CheckoutsController#create`, capture the resolved postcode once (it's currently computed inline in the builder call), pass mode params to the builder, and branch the redirect. The builder call becomes:
 
@@ -666,12 +666,12 @@ In `CheckoutsController#create`, capture the resolved postcode once (it's curren
 
 Everything above the builder call (guards, `checkout.started`, `cart.checkout_initiated`, rate limit) is untouched. Note the fingerprint is computed AFTER the invalid-discount cleanup so it uses the post-cleanup `session[:discount_code]` — if the welcome code was invalid and deleted, the fingerprint must reflect no-discount, matching what the Stripe session was actually built without... **No — stop.** The Stripe session was built WITH the attempt and fell back to `allow_promotion_codes`; the GET page's recompute will read the (now deleted) `session[:discount_code]` as nil. Computing the stash fingerprint after the delete makes both sides nil ⇒ they match ⇒ no false bounce. That is why the stash block sits below the invalid-discount cleanup. Keep that ordering.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
 Expected: PASS, new and old.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add app/controllers/checkouts_controller.rb test/controllers/checkouts_controller_test.rb test/support/stripe_test_helper.rb
@@ -690,7 +690,7 @@ git commit -m "Stash custom checkout session and redirect to GET checkout page"
 
 `GET /checkout` already routes to `checkouts#show` (empty template today, so it renders a blank page). Give it a real action: flag off or no stash → cart; stale fingerprint → discard stash, bounce to cart with notice; otherwise render.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```ruby
   # --- GET /checkout (on-site page) ---
@@ -762,12 +762,12 @@ git commit -m "Stash custom checkout session and redirect to GET checkout page"
   end
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
 Expected: new tests FAIL (`show` currently renders the empty template with 200 for everyone).
 
-- [ ] **Step 3: Implement the action**
+- [x] **Step 3: Implement the action**
 
 Add to `CheckoutsController` (above `success`):
 
@@ -801,7 +801,7 @@ Add to `CheckoutsController` (above `success`):
 
 (Verify `email_address` vs `email` on User and `default_first` on the addresses association — both appear in existing code: `session_builder.rb` uses `user.email_address`; `application_controller.rb#default_address_postcode` uses `addresses&.default_first&.first`.)
 
-- [ ] **Step 4: Implement the view**
+- [x] **Step 4: Implement the view**
 
 `app/views/checkouts/show.html.erb`:
 
@@ -932,12 +932,12 @@ Add to `CheckoutsController` (above `success`):
 
 (Check `app/helpers` for where `cart_summary_lines` and `cart_summary_line_dom_id` live and what `line[:kind]` values exist — mirror them; do NOT reuse the `#cart_summary` DOM id, which the cart page's Turbo Streams own.)
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add app/controllers/checkouts_controller.rb app/views/checkouts/show.html.erb app/views/checkouts/_summary.html.erb test/controllers/checkouts_controller_test.rb
@@ -954,13 +954,13 @@ git commit -m "Render the on-site checkout page from the stashed session"
 
 Nothing client-side ever needed the publishable key before (hosted checkout is a redirect), so it may not be wired.
 
-- [ ] **Step 1: Check and wire the publishable key**
+- [x] **Step 1: Check and wire the publishable key**
 
 Run: `grep -rn "publishable" config/ app/ | grep -v node_modules`
 
 If `Rails.configuration.stripe[:publishable_key]` is not populated, add it where the stripe config hash is built (same pattern as `secret_key`, sourced from credentials — see `docs/runbooks/credentials.md` for the vault; sandbox and live keys differ). If the credentials key is missing, add it via `bin/rails credentials:edit` per the runbook and note it in the PR description.
 
-- [ ] **Step 2: Assert it in a test**
+- [x] **Step 2: Assert it in a test**
 
 Add to `test/controllers/checkouts_controller_test.rb`'s "show renders the page from a fresh stash" test:
 
@@ -973,7 +973,7 @@ Add to `test/controllers/checkouts_controller_test.rb`'s "show renders the page 
 
 Run: `bin/rails test test/controllers/checkouts_controller_test.rb` — PASS (fix config until it does).
 
-- [ ] **Step 3: CSP additions**
+- [x] **Step 3: CSP additions**
 
 In `config/initializers/content_security_policy.rb` (currently report-only, so this can't break production, but must be right before the flag flips):
 
@@ -996,7 +996,7 @@ In `config/initializers/content_security_policy.rb` (currently report-only, so t
 
 (Per Stripe's CSP documentation for Stripe.js/Elements: `script-src js.stripe.com`, `frame-src js.stripe.com hooks.stripe.com`, `connect-src api.stripe.com`. Verify against https://docs.stripe.com/security/guide#content-security-policy at implementation time and add any host the report-only console flags on staging.)
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add config/initializers/content_security_policy.rb config/initializers/stripe.rb test/controllers/checkouts_controller_test.rb
@@ -1015,7 +1015,7 @@ No JS test framework exists in this repo; this task is verified by Task 9's syst
 
 **API verification step is part of this task:** the code below targets Stripe.js's checkout SDK ("Elements with Checkout Sessions API", `stripe.initCheckout`) as documented at https://docs.stripe.com/checkout/custom/quickstart and https://docs.stripe.com/js/custom_checkout. Before writing, open those pages and verify these exact names: `initCheckout`, `createPaymentElement`, `createShippingAddressElement`, `session()`, `on("change")`, `updateEmail`, `applyPromotionCode`, `removePromotionCode`, `confirm`, and the shape of `session.total`. Where a name differs, follow the docs — the structure below stands.
 
-- [ ] **Step 1: Write the controller**
+- [x] **Step 1: Write the controller**
 
 ```js
 // app/frontend/javascript/controllers/onsite_checkout_controller.js
@@ -1185,7 +1185,7 @@ export default class extends Controller {
 }
 ```
 
-- [ ] **Step 2: Register it lazily**
+- [x] **Step 2: Register it lazily**
 
 In `app/frontend/entrypoints/application.js`, add to the `lazyControllers` map (alphabetical position, matching the file's style):
 
@@ -1193,12 +1193,12 @@ In `app/frontend/entrypoints/application.js`, add to the `lazyControllers` map (
   "onsite-checkout": () => import("../javascript/controllers/onsite_checkout_controller"),
 ```
 
-- [ ] **Step 3: Verify the build**
+- [x] **Step 3: Verify the build**
 
 Run: `bin/vite build` (or `bin/dev` and load any page watching the console)
 Expected: build succeeds, no import errors.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add app/frontend/javascript/controllers/onsite_checkout_controller.js app/frontend/entrypoints/application.js
@@ -1214,7 +1214,7 @@ git commit -m "Wire the on-site checkout page to Stripe's checkout SDK"
 
 Per the spec: assert the page renders with summary, mount points, and promo control. Do NOT drive the real Stripe iframe in CI (flaky by design); confirm-and-pay is the staging checklist's job. System tests run the app in-process, so Mocha stubs apply.
 
-- [ ] **Step 1: Write the test**
+- [x] **Step 1: Write the test**
 
 ```ruby
 # test/system/onsite_checkout_page_test.rb
@@ -1250,17 +1250,17 @@ end
 
 Before running: open the cart page views to confirm the real labels for the add-to-cart and checkout buttons and the product path helper, and adjust the three marked lines. If `StripeTestHelper` works in system tests (it's included via `test/support`), prefer `stub_stripe_tax_rate_list` + `build_custom_stripe_session` over the inline stubs above.
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 Run: `bin/rails test:system test/system/onsite_checkout_page_test.rb`
 Expected: PASS. (The Stimulus controller will attempt `initCheckout` against the fake secret and fail in the browser console — the test only asserts server-rendered markup, so that's fine.)
 
-- [ ] **Step 3: Run the full suite**
+- [x] **Step 3: Run the full suite**
 
 Run: `bin/rails test && bin/rails test:system`
 Expected: PASS across the board.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add test/system/onsite_checkout_page_test.rb
@@ -1274,18 +1274,18 @@ git commit -m "Add system test for the on-site checkout page render"
 **Files:**
 - Modify: `docs/developer_guide.md` (the "Checkout & Orders" section, ~lines 282–360)
 
-- [ ] **Step 1: Rewrite the stale section**
+- [x] **Step 1: Rewrite the stale section**
 
 The current section shows a `shipping_options`-based flow (£4.99/£9.99) that predates zones and doesn't match `Checkout::SessionBuilder`. Replace it with an accurate description covering: `Checkout::SessionBuilder` (line items with the prepended taxed shipping line, `ShippingZone` pricing from the cart-page postcode, discounts via promotion-code resolution, `allow_promotion_codes` on the no-code path); the two ui_modes (hosted redirect vs on-site PRG flow: `#create` → stash + fingerprint → `GET /checkout` → Stripe custom-UI SDK → `return_url` to `#success`); the `OnsiteCheckout` ENV flag; and a pointer to the spec and ADR 0001. Pull code snippets from the REAL files, not from memory.
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add docs/developer_guide.md
 git commit -m "Rewrite developer guide checkout section for zones and on-site mode"
 ```
 
-- [ ] **Step 3: Rollout checklist** (record in the PR description; these are ops steps, not code)
+- [x] **Step 3: Rollout checklist** (record in the PR description; these are ops steps, not code)
 
 1. Register **afida.com** and the staging domain for Apple Pay in the Stripe dashboard — **sandbox AND live**. A missed live registration silently hides the wallet button; nothing errors.
 2. Confirm `stripe.publishable_key` exists in BOTH sandbox and live credentials.

--- a/docs/superpowers/plans/2026-07-28-onsite-checkout.md
+++ b/docs/superpowers/plans/2026-07-28-onsite-checkout.md
@@ -1,3 +1,10 @@
+---
+type: Plan
+description: Task-by-task implementation plan for the on-site Stripe checkout page (ui_mode custom behind the ONSITE_CHECKOUT flag) replacing the hosted redirect.
+status: active
+timestamp: 2026-07-28
+---
+
 # On-Site Checkout Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-07-28-onsite-checkout.md
+++ b/docs/superpowers/plans/2026-07-28-onsite-checkout.md
@@ -1,0 +1,1300 @@
+# On-Site Checkout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Checkout happens on afida.com (order summary, email, address, promo code, Stripe payment inputs) instead of redirecting to Stripe's hosted page, behind an ENV flag with instant hosted fallback.
+
+**Architecture:** `Checkout::SessionBuilder` gains a `:custom` ui_mode; `CheckoutsController#create` (flag on) stashes the session's client secret + a cart fingerprint in the Rails session and 303-redirects to `GET /checkout`, which renders the page. Stripe.js's checkout SDK (`initCheckout`) binds the page to the session; Stripe stays the money-math authority. Spec: `docs/superpowers/specs/2026-07-28-onsite-checkout-design.md`. ADR: `docs/adr/0001-onsite-checkout-on-checkout-sessions.md`.
+
+**Tech Stack:** Rails 8.1, stripe gem 19.3 (API `2025-12-15.clover`), Vite + Stimulus 3, Tailwind/daisyUI, Minitest + Mocha (`StripeTestHelper`), Selenium system tests.
+
+**Branch:** all work on `onsite-checkout`. One commit per task, no Co-Authored-By lines.
+
+**Conventions you must follow:**
+- TDD: write the failing test, run it, watch it fail, implement, watch it pass, commit.
+- Stripe is stubbed with Mocha at the Ruby class level (never WebMock). Look at `test/support/stripe_test_helper.rb` before writing any Stripe stub; reuse its builders.
+- Tests can't write `session[]` directly; set the delivery postcode via `post delivery_postcode_cart_path, params: { delivery_postcode: "WD18 9SB" }` (helper `set_delivery_postcode` already exists in `test/controllers/checkouts_controller_test.rb`).
+- Run a focused file with `bin/rails test test/path/file_test.rb`; the full suite with `bin/rails test`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| Create `app/models/onsite_checkout.rb` | The feature flag, read live from ENV |
+| Modify `app/services/checkout/session_builder.rb` | `ui_mode:`/`return_url:` keywords; custom-mode params; expose priced zone on `Result` |
+| Create `app/controllers/shipping_zones_controller.rb` | Read-only postcode→zone JSON endpoint for the zone guard |
+| Create `app/services/checkout/cart_fingerprint.rb` | Staleness fingerprint (cart items + postcode + discount code) |
+| Modify `app/controllers/checkouts_controller.rb` | Flag branch in `#create` (stash + PRG); real `#show` action |
+| Modify `config/routes.rb` | `resource :shipping_zone, only: :show` |
+| Replace `app/views/checkouts/show.html.erb` (currently 0 bytes) | The checkout page |
+| Create `app/views/checkouts/_summary.html.erb` | Order summary with Stimulus money-line targets |
+| Create `app/frontend/javascript/controllers/onsite_checkout_controller.js` | All SDK wiring: mount, email, totals, promo, zone guard, confirm |
+| Modify `app/frontend/entrypoints/application.js` | Lazy-register `onsite-checkout` |
+| Modify `config/initializers/content_security_policy.rb` | Stripe hosts |
+| Modify `config/initializers/stripe.rb` (or wherever `Rails.configuration.stripe` is built) | Ensure `publishable_key` is exposed |
+| Modify `docs/developer_guide.md` | Rewrite stale "Checkout & Orders" section |
+| Test files | `test/models/onsite_checkout_test.rb`, `test/services/checkout/cart_fingerprint_test.rb`, `test/controllers/shipping_zones_controller_test.rb`, additions to `test/services/checkout/session_builder_test.rb` and `test/controllers/checkouts_controller_test.rb`, `test/system/onsite_checkout_page_test.rb` |
+
+---
+
+### Task 1: OnsiteCheckout flag
+
+**Files:**
+- Create: `app/models/onsite_checkout.rb`
+- Test: `test/models/onsite_checkout_test.rb`
+
+The flag must read ENV **at call time** (no constant memoization) so ops can flip it with an env change + redeploy and tests can stub it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/models/onsite_checkout_test.rb
+require "test_helper"
+
+class OnsiteCheckoutTest < ActiveSupport::TestCase
+  test "disabled when ONSITE_CHECKOUT is unset" do
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(nil)
+    assert_not OnsiteCheckout.enabled?
+  end
+
+  test "enabled for truthy values" do
+    %w[true 1].each do |value|
+      ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(value)
+      assert OnsiteCheckout.enabled?, "expected #{value.inspect} to enable"
+    end
+  end
+
+  test "disabled for falsy or junk values" do
+    [ "false", "0", "", "banana" ].each do |value|
+      ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(value)
+      assert_not OnsiteCheckout.enabled?, "expected #{value.inspect} to disable"
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/models/onsite_checkout_test.rb`
+Expected: FAIL / error with `NameError: uninitialized constant OnsiteCheckout`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# app/models/onsite_checkout.rb
+#
+# Whether checkout renders on afida.com (Stripe custom UI) instead of
+# redirecting to Stripe's hosted page. Read from ENV on every call, not into a
+# constant, so flipping back to hosted is an env change + redeploy with no code
+# edit — the rollback lever the spec promises.
+class OnsiteCheckout
+  TRUTHY = %w[true 1].freeze
+
+  def self.enabled?
+    TRUTHY.include?(ENV["ONSITE_CHECKOUT"].to_s.strip.downcase)
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/models/onsite_checkout_test.rb`
+Expected: PASS (3 runs, 0 failures)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/onsite_checkout.rb test/models/onsite_checkout_test.rb
+git commit -m "Add OnsiteCheckout flag read live from ENV"
+```
+
+---
+
+### Task 2: SessionBuilder custom mode
+
+**Files:**
+- Modify: `app/services/checkout/session_builder.rb`
+- Test: `test/services/checkout/session_builder_test.rb`
+
+Custom mode differs from hosted in EXACTLY three ways: `ui_mode: "custom"` + `return_url` (replacing `success_url`/`cancel_url`), and `payment_method_types: ["card", "link"]` (wallets ride on card inside the Payment Element). Everything else — line items with the prepended taxed shipping line, zone resolution, metadata, discount branches, `allow_promotion_codes`, customer details, `Result` signalling — must be shared by construction. Also expose the priced zone on `Result` so the controller can stash it without re-deriving.
+
+The existing test file's helpers (`build_session`, `build_stripe_session`, `stub_stripe_tax_rate_list`) are the idiom; read its first ~60 lines before starting.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/services/checkout/session_builder_test.rb` (inside the existing class, reusing its `setup`):
+
+```ruby
+  # --- custom (on-site) mode ---
+
+  # Build via the same private helper the file already uses, but in custom mode.
+  # If the file's build_session helper doesn't take extra kwargs, extend it to
+  # pass ui_mode:/return_url: through to Checkout::SessionBuilder.new.
+  def build_custom_session(**kwargs)
+    build_session(ui_mode: :custom, return_url: "https://example.com/checkout/success?session_id={CHECKOUT_SESSION_ID}", **kwargs)
+  end
+
+  test "custom mode differs from hosted only in ui_mode, URLs, and payment methods" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured = []
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured << params
+      true
+    end.returns(build_stripe_session)
+
+    build_session
+    build_custom_session
+
+    hosted, custom = captured
+
+    assert_equal "custom", custom[:ui_mode]
+    assert_equal "https://example.com/checkout/success?session_id={CHECKOUT_SESSION_ID}", custom[:return_url]
+    assert_nil custom[:success_url]
+    assert_nil custom[:cancel_url]
+    assert_equal [ "card", "link" ], custom[:payment_method_types]
+
+    # Everything else must be identical — this is the parity contract the
+    # hosted fallback depends on. Shipping line item drift here costs money.
+    mode_keys = [ :ui_mode, :return_url, :success_url, :cancel_url, :payment_method_types ]
+    assert_equal hosted.except(*mode_keys), custom.except(*mode_keys)
+  end
+
+  test "custom mode pins the shipping line item exactly as hosted does" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_custom_session(delivery_postcode: "IV51 9XX")
+
+    shipping_line = captured_params[:line_items].first
+    assert_equal Shipping::LINE_ITEM_FLAG, shipping_line[:price_data][:product_data][:metadata]
+    assert_equal Shipping.cost_for_zone(:highlands), shipping_line[:price_data][:unit_amount]
+    assert_equal "highlands", captured_params[:metadata][:shipping_zone]
+  end
+
+  test "custom mode keeps allow_promotion_codes on the no-code path" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_custom_session
+
+    assert_equal true, captured_params[:allow_promotion_codes]
+  end
+
+  test "result exposes the priced zone" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+    Stripe::Checkout::Session.stubs(:create).returns(build_stripe_session)
+
+    assert_equal :highlands, build_session(delivery_postcode: "IV51 9XX").zone
+    assert_equal :mainland, build_session(delivery_postcode: "WD18 9SB").zone
+  end
+```
+
+Note on `build_session`: the existing helper takes kwargs like `discount_code:`/`delivery_postcode:` and forwards to `Checkout::SessionBuilder.new`. Extend its signature to also forward `ui_mode:` and `return_url:` (defaulting so every existing call is untouched).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/services/checkout/session_builder_test.rb`
+Expected: new tests FAIL (`unknown keyword: :ui_mode` and `NoMethodError: undefined method 'zone'`); ALL existing tests still PASS.
+
+- [ ] **Step 3: Implement**
+
+In `app/services/checkout/session_builder.rb`:
+
+```ruby
+    Result = Struct.new(:session, :invalid_discount_code, :selected_address_id, :zone, keyword_init: true) do
+      def invalid_discount?
+        invalid_discount_code.present?
+      end
+    end
+```
+
+Constructor — add the two keywords (hosted default keeps every existing caller working):
+
+```ruby
+    def initialize(cart:, user:, address_id:, discount_code:, datafast_visitor_id:, datafast_session_id:, success_url:, cancel_url:, delivery_postcode: nil, ui_mode: :hosted, return_url: nil)
+      @cart = cart
+      @user = user
+      @address_id = address_id
+      @discount_code = discount_code
+      @delivery_postcode = delivery_postcode
+      @datafast_visitor_id = datafast_visitor_id
+      @datafast_session_id = datafast_session_id
+      @success_url = success_url
+      @cancel_url = cancel_url
+      @ui_mode = ui_mode
+      @return_url = return_url
+    end
+```
+
+`create` — add `zone: zone` to the `Result.new` call:
+
+```ruby
+      Result.new(
+        session: Stripe::Checkout::Session.create(session_params),
+        invalid_discount_code: invalid_discount_code,
+        selected_address_id: selected_address_id,
+        zone: zone
+      )
+```
+
+`build_session_params` — replace the hardcoded mode bits with a merge (the shared core stays in one hash literal so it CANNOT drift between modes):
+
+```ruby
+    def build_session_params
+      {
+        line_items: line_items,
+        mode: "payment",
+        shipping_address_collection: {
+          allowed_countries: Shipping::ALLOWED_COUNTRIES
+        },
+        metadata: {
+          cart_id: cart.id.to_s,
+          discount_code: discount_code,
+          datafast_visitor_id: datafast_visitor_id,
+          datafast_session_id: datafast_session_id,
+          # The zone the order was PRICED against, which is not necessarily the
+          # zone of the address collected during payment. The order records what
+          # the customer was actually charged, so it reads this back rather than
+          # re-deriving from the delivered-to postcode.
+          shipping_zone: zone.to_s
+        }
+      }.merge(mode_params)
+    end
+
+    # The ONLY params allowed to differ between hosted and custom mode. The
+    # custom (on-site) page shows wallets and Link inside the Payment Element;
+    # hosted stays card-only exactly as it always was.
+    def mode_params
+      if ui_mode == :custom
+        {
+          ui_mode: "custom",
+          return_url: return_url,
+          payment_method_types: [ "card", "link" ]
+        }
+      else
+        {
+          payment_method_types: [ "card" ],
+          success_url: success_url,
+          cancel_url: cancel_url
+        }
+      end
+    end
+```
+
+Add `:ui_mode, :return_url` to the private `attr_reader` list.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/services/checkout/session_builder_test.rb`
+Expected: PASS, including all pre-existing tests.
+
+- [ ] **Step 5: Run the controller tests too** (they drive the builder through `#create`)
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
+Expected: PASS unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/checkout/session_builder.rb test/services/checkout/session_builder_test.rb
+git commit -m "Teach SessionBuilder a custom ui_mode sharing all core params"
+```
+
+---
+
+### Task 3: Shipping-zone endpoint (zone guard, server half)
+
+**Files:**
+- Create: `app/controllers/shipping_zones_controller.rb`
+- Modify: `config/routes.rb`
+- Test: `test/controllers/shipping_zones_controller_test.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/controllers/shipping_zones_controller_test.rb
+require "test_helper"
+
+class ShippingZonesControllerTest < ActionDispatch::IntegrationTest
+  test "resolves a mainland postcode" do
+    get shipping_zone_path, params: { postcode: "WD18 9SB" }
+
+    assert_response :success
+    assert_equal({ "zone" => "mainland", "deliverable" => true }, response.parsed_body)
+  end
+
+  test "resolves a highlands postcode" do
+    get shipping_zone_path, params: { postcode: "IV51 9XX" }
+
+    assert_equal "highlands", response.parsed_body["zone"]
+  end
+
+  test "resolves an outward code alone, as the cart field does" do
+    get shipping_zone_path, params: { postcode: "BT1" }
+
+    assert_equal({ "zone" => "northern_ireland", "deliverable" => true }, response.parsed_body)
+  end
+
+  test "unparseable postcode is unknown and not deliverable" do
+    get shipping_zone_path, params: { postcode: "banana" }
+
+    assert_equal({ "zone" => "unknown", "deliverable" => false }, response.parsed_body)
+  end
+
+  test "works logged out" do
+    get shipping_zone_path, params: { postcode: "SW1A 1AA" }
+
+    assert_response :success
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/controllers/shipping_zones_controller_test.rb`
+Expected: FAIL with `NameError: undefined local variable or method 'shipping_zone_path'`
+
+- [ ] **Step 3: Implement**
+
+In `config/routes.rb`, next to `resource :checkout`:
+
+```ruby
+  # Read-only postcode→zone lookup for the on-site checkout's zone guard.
+  # Deliberately outside checkout's rate limit: it fires on address keystrokes.
+  resource :shipping_zone, only: [ :show ]
+```
+
+```ruby
+# app/controllers/shipping_zones_controller.rb
+#
+# The zone guard's server half: resolves a postcode to its shipping zone so the
+# on-site checkout page can compare the address being typed against the zone
+# the order was priced for. Read-only, session-free, public — it exposes
+# nothing the delivery page doesn't already publish.
+class ShippingZonesController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    zone = ShippingZone.for(params[:postcode])
+    render json: { zone: zone, deliverable: ShippingZone.deliverable?(zone) }
+  end
+end
+```
+
+(If `allow_unauthenticated_access` is not how public controllers opt out in this app, mirror whatever `CheckoutsController` does — it has `allow_unauthenticated_access` at the top.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/controllers/shipping_zones_controller_test.rb`
+Expected: PASS (5 runs)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/shipping_zones_controller.rb config/routes.rb test/controllers/shipping_zones_controller_test.rb
+git commit -m "Add read-only shipping-zone lookup endpoint for the zone guard"
+```
+
+---
+
+### Task 4: Cart fingerprint
+
+**Files:**
+- Create: `app/services/checkout/cart_fingerprint.rb`
+- Test: `test/services/checkout/cart_fingerprint_test.rb`
+
+The staleness fingerprint: same cart items + same postcode + same discount code ⇒ same digest. Any input change ⇒ different digest.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# test/services/checkout/cart_fingerprint_test.rb
+require "test_helper"
+
+class Checkout::CartFingerprintTest < ActiveSupport::TestCase
+  setup do
+    @cart = Cart.create!
+    @cart.cart_items.create!(product: products(:one), quantity: 2, price: 10.00)
+  end
+
+  def digest(cart: @cart, postcode: "WD18 9SB", discount_code: nil)
+    Checkout::CartFingerprint.digest(cart: cart, postcode: postcode, discount_code: discount_code)
+  end
+
+  test "stable for identical inputs" do
+    assert_equal digest, digest
+  end
+
+  test "changes when a quantity changes" do
+    before = digest
+    @cart.cart_items.first.update!(quantity: 3)
+    assert_not_equal before, digest
+  end
+
+  test "changes when an item is added" do
+    before = digest
+    @cart.cart_items.create!(product: products(:two), quantity: 1, price: 30.00)
+    assert_not_equal before, digest
+  end
+
+  test "changes when the postcode changes zone-or-not" do
+    assert_not_equal digest(postcode: "WD18 9SB"), digest(postcode: "IV51 9XX")
+  end
+
+  test "insensitive to postcode case and whitespace" do
+    assert_equal digest(postcode: "WD18 9SB"), digest(postcode: " wd18 9sb ")
+  end
+
+  test "changes when the discount code changes" do
+    assert_not_equal digest(discount_code: nil), digest(discount_code: "coupon_abc")
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bin/rails test test/services/checkout/cart_fingerprint_test.rb`
+Expected: FAIL with `NameError: uninitialized constant Checkout::CartFingerprint`
+
+- [ ] **Step 3: Implement**
+
+```ruby
+# app/services/checkout/cart_fingerprint.rb
+module Checkout
+  # Staleness fingerprint for a stashed on-site checkout session. The Stripe
+  # session freezes line items and shipping price at #create; if the inputs
+  # that produced them change before the GET page renders (cart edited in
+  # another tab, postcode retyped, discount claimed), the stash must be
+  # discarded rather than charged. Same inputs ⇒ same digest.
+  class CartFingerprint
+    def self.digest(cart:, postcode:, discount_code:)
+      payload = {
+        items: cart.cart_items.order(:id).map do |item|
+          [ item.id, item.product_id, item.quantity, item.price.to_s, item.sample?, item.configuration ]
+        end,
+        postcode: postcode.to_s.upcase.strip.squeeze(" "),
+        discount_code: discount_code.to_s
+      }
+      Digest::SHA256.hexdigest(payload.to_json)
+    end
+  end
+end
+```
+
+(If `item.sample?` or `item.configuration` doesn't exist on CartItem, check the model — `SessionBuilder#stripe_quantity` calls `item.sample?` and `item.configured?`/`item.configuration["size"]`, so both exist.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bin/rails test test/services/checkout/cart_fingerprint_test.rb`
+Expected: PASS (6 runs)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/checkout/cart_fingerprint.rb test/services/checkout/cart_fingerprint_test.rb
+git commit -m "Add cart fingerprint for on-site checkout staleness checks"
+```
+
+---
+
+### Task 5: `#create` PRG branch (flag on → stash + redirect)
+
+**Files:**
+- Modify: `app/controllers/checkouts_controller.rb`
+- Test: `test/controllers/checkouts_controller_test.rb`
+
+Flag off: byte-for-byte today's behaviour. Flag on: same guards and events, builder in custom mode, stash `{session_id, client_secret, fingerprint, postcode, zone}` under `session[:onsite_checkout]`, 303 to `checkout_path`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/controllers/checkouts_controller_test.rb`. The custom-mode Stripe session stub needs a `client_secret`; check `test/support/stripe_test_helper.rb` for `build_stripe_session` — if it doesn't accept overrides, add alongside it:
+
+```ruby
+  # test/support/stripe_test_helper.rb — custom-mode session: no redirect URL,
+  # has a client secret for the on-site page.
+  def build_custom_stripe_session
+    stub(
+      id: "sess_custom_123",
+      url: nil,
+      client_secret: "cs_test_secret_abc",
+      payment_status: "unpaid"
+    )
+  end
+```
+
+(Mirror whatever attributes `build_stripe_session` stubs — same `stub(...)` style, same id format if tests elsewhere match on it.)
+
+Then the tests:
+
+```ruby
+  def enable_onsite_checkout
+    ENV.stubs(:[]).returns(nil)                     # keep other ENV reads working
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns("true")
+  end
+```
+
+**Careful:** the blanket `ENV.stubs(:[]).returns(nil)` line above is dangerous if anything else reads ENV during the request (ShippingZone cost overrides do: `ENV.fetch`, which does NOT go through `[]`). Prefer the narrower form — stub only the one key and let everything else through:
+
+```ruby
+  def enable_onsite_checkout
+    OnsiteCheckout.stubs(:enabled?).returns(true)
+  end
+```
+
+Use the `OnsiteCheckout.stubs` form. The flag class has its own ENV tests (Task 1); controller tests stub the seam.
+
+```ruby
+  # --- on-site checkout (flag on) ---
+
+  test "create with flag on builds a custom-mode session and redirects to the checkout page" do
+    enable_onsite_checkout
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_custom_stripe_session)
+
+    post checkout_path
+
+    assert_redirected_to checkout_path
+    assert_response :see_other
+    assert_equal "custom", captured_params[:ui_mode]
+    assert_match %r{/checkout/success\?session_id=\{CHECKOUT_SESSION_ID\}}, captured_params[:return_url]
+    assert_nil captured_params[:success_url]
+
+    stash = session[:onsite_checkout]
+    assert_equal "sess_custom_123", stash["session_id"]
+    assert_equal "cs_test_secret_abc", stash["client_secret"]
+    assert_equal "mainland", stash["zone"]
+    assert stash["fingerprint"].present?
+    assert_equal "WD18 9SB", stash["postcode"]
+  end
+
+  test "create with flag on still refuses an empty cart" do
+    enable_onsite_checkout
+    @cart.cart_items.destroy_all
+
+    post checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "create with flag on still refuses an undeliverable destination" do
+    enable_onsite_checkout
+    set_delivery_postcode("IM1 1AA")   # Isle of Man: undeliverable
+
+    post checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "create with flag off never stashes" do
+    stub_stripe_session_create
+
+    post checkout_path
+
+    assert_match %r{https://checkout\.stripe\.com}, response.redirect_url
+    assert_nil session[:onsite_checkout]
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
+Expected: the four new tests FAIL (flag-on posts still redirect to checkout.stripe.com; no stash). All existing tests PASS.
+
+- [ ] **Step 3: Implement**
+
+In `CheckoutsController#create`, capture the resolved postcode once (it's currently computed inline in the builder call), pass mode params to the builder, and branch the redirect. The builder call becomes:
+
+```ruby
+      resolved_postcode = delivery_postcode_for(params[:address_id])
+
+      builder = Checkout::SessionBuilder.new(
+        cart: cart,
+        user: Current.user,
+        address_id: params[:address_id],
+        discount_code: session[:discount_code],
+        delivery_postcode: resolved_postcode,
+        datafast_visitor_id: cookies[:datafast_visitor_id],
+        datafast_session_id: cookies[:datafast_session_id],
+        success_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: cancel_checkout_url,
+        ui_mode: OnsiteCheckout.enabled? ? :custom : :hosted,
+        return_url: success_checkout_url + "?session_id={CHECKOUT_SESSION_ID}"
+      )
+      result = builder.create
+
+      if result.invalid_discount?
+        session.delete(:discount_code)
+        flash[:alert] = "Your discount code could not be applied. Please continue with your order."
+      end
+
+      session[:selected_address_id] = result.selected_address_id if result.selected_address_id.present?
+
+      if OnsiteCheckout.enabled?
+        session[:onsite_checkout] = {
+          "session_id" => result.session.id,
+          "client_secret" => result.session.client_secret,
+          "fingerprint" => Checkout::CartFingerprint.digest(
+            cart: cart, postcode: resolved_postcode, discount_code: session[:discount_code]
+          ),
+          "postcode" => resolved_postcode,
+          "zone" => result.zone.to_s
+        }
+        redirect_to checkout_path, status: :see_other
+      else
+        redirect_to result.session.url, allow_other_host: true, status: :see_other
+      end
+```
+
+Everything above the builder call (guards, `checkout.started`, `cart.checkout_initiated`, rate limit) is untouched. Note the fingerprint is computed AFTER the invalid-discount cleanup so it uses the post-cleanup `session[:discount_code]` — if the welcome code was invalid and deleted, the fingerprint must reflect no-discount, matching what the Stripe session was actually built without... **No — stop.** The Stripe session was built WITH the attempt and fell back to `allow_promotion_codes`; the GET page's recompute will read the (now deleted) `session[:discount_code]` as nil. Computing the stash fingerprint after the delete makes both sides nil ⇒ they match ⇒ no false bounce. That is why the stash block sits below the invalid-discount cleanup. Keep that ordering.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
+Expected: PASS, new and old.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/checkouts_controller.rb test/controllers/checkouts_controller_test.rb test/support/stripe_test_helper.rb
+git commit -m "Stash custom checkout session and redirect to GET checkout page"
+```
+
+---
+
+### Task 6: `#show` action + page skeleton
+
+**Files:**
+- Modify: `app/controllers/checkouts_controller.rb`
+- Replace: `app/views/checkouts/show.html.erb` (currently a 0-byte placeholder)
+- Create: `app/views/checkouts/_summary.html.erb`
+- Test: `test/controllers/checkouts_controller_test.rb`
+
+`GET /checkout` already routes to `checkouts#show` (empty template today, so it renders a blank page). Give it a real action: flag off or no stash → cart; stale fingerprint → discard stash, bounce to cart with notice; otherwise render.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+  # --- GET /checkout (on-site page) ---
+
+  def stash_onsite_session
+    enable_onsite_checkout
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+    post checkout_path
+    assert_redirected_to checkout_path
+  end
+
+  test "show renders the page from a fresh stash" do
+    stash_onsite_session
+
+    get checkout_path
+
+    assert_response :success
+    assert_match "cs_test_secret_abc", response.body
+    assert_select "[data-controller='onsite-checkout']"
+    assert_select "[data-onsite-checkout-target='payment']"
+    assert_select "[data-onsite-checkout-target='address']"
+  end
+
+  test "show redirects to cart when the flag is off" do
+    get checkout_path
+    assert_redirected_to cart_path
+  end
+
+  test "show redirects to cart without a stash" do
+    enable_onsite_checkout
+    get checkout_path
+    assert_redirected_to cart_path
+  end
+
+  test "show bounces a stale stash to the cart and discards it" do
+    stash_onsite_session
+
+    @cart.cart_items.first.update!(quantity: 5)   # cart changed in "another tab"
+
+    get checkout_path
+
+    assert_redirected_to cart_path
+    assert_equal "Your basket changed. Continue to payment when you're ready.", flash[:notice]
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show shows the promo control only when no server discount and not samples-only" do
+    stash_onsite_session
+    get checkout_path
+    assert_select "[data-onsite-checkout-target='promoSection']"
+  end
+
+  test "invalid welcome coupon renders the alert AND the promo control together" do
+    # The spec's pinned combination: #create fell back to allow_promotion_codes
+    # and deleted the session discount, so the GET page must show the failure
+    # alert while still offering the promo input (the shopper can retype).
+    enable_onsite_checkout
+    post email_subscriptions_path, params: { email: "promo-test@example.com" }
+    Stripe::PromotionCode.stubs(:list).returns(stub(data: []))
+    Stripe::Coupon.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("No such coupon", nil))
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+
+    post checkout_path
+    follow_redirect!
+
+    assert_response :success
+    assert_match "Your discount code could not be applied", response.body
+    assert_select "[data-onsite-checkout-target='promoSection']"
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
+Expected: new tests FAIL (`show` currently renders the empty template with 200 for everyone).
+
+- [ ] **Step 3: Implement the action**
+
+Add to `CheckoutsController` (above `success`):
+
+```ruby
+  # The on-site checkout page. Renders the Stripe session stashed by #create;
+  # performs no Stripe writes, so refresh and back-navigation are free.
+  def show
+    return redirect_to cart_path unless OnsiteCheckout.enabled?
+
+    stash = session[:onsite_checkout]
+    cart = Current.cart
+    return redirect_to cart_path if stash.blank? || cart.blank? || cart.cart_items.empty?
+
+    postcode = session[:delivery_postcode].presence || stash["postcode"]
+    fingerprint = Checkout::CartFingerprint.digest(
+      cart: cart, postcode: postcode, discount_code: session[:discount_code]
+    )
+    if fingerprint != stash["fingerprint"]
+      session.delete(:onsite_checkout)
+      return redirect_to cart_path, notice: "Your basket changed. Continue to payment when you're ready."
+    end
+
+    @client_secret = stash["client_secret"]
+    @priced_zone = stash["zone"]
+    @show_promo = session[:discount_code].blank? && !cart.only_samples?
+    @prefill_address = Current.user&.addresses&.find_by(id: session[:selected_address_id]) ||
+                       Current.user&.addresses&.default_first&.first
+    @customer_email = Current.user&.email_address
+  end
+```
+
+(Verify `email_address` vs `email` on User and `default_first` on the addresses association — both appear in existing code: `session_builder.rb` uses `user.email_address`; `application_controller.rb#default_address_postcode` uses `addresses&.default_first&.first`.)
+
+- [ ] **Step 4: Implement the view**
+
+`app/views/checkouts/show.html.erb`:
+
+```erb
+<% content_for :title, "Checkout | Afida" %>
+<% content_for :head do %>
+  <script src="https://js.stripe.com/v3/"></script>
+<% end %>
+
+<div class="max-w-6xl mx-auto px-4 py-8"
+     data-controller="onsite-checkout"
+     data-onsite-checkout-client-secret-value="<%= @client_secret %>"
+     data-onsite-checkout-publishable-key-value="<%= Rails.configuration.stripe[:publishable_key] %>"
+     data-onsite-checkout-priced-zone-value="<%= @priced_zone %>"
+     data-onsite-checkout-guest-value="<%= Current.user.blank? %>"
+     data-onsite-checkout-prefill-value="<%= {
+       name: @prefill_address&.recipient_name,
+       line1: @prefill_address&.line1,
+       line2: @prefill_address&.line2,
+       city: @prefill_address&.city,
+       postal_code: @prefill_address&.postcode,
+       country: "GB"
+     }.compact.to_json %>">
+
+  <h1 class="text-2xl sm:text-3xl mb-6">Checkout</h1>
+
+  <div class="flex flex-col-reverse md:flex-row gap-8">
+    <div class="w-full md:w-3/5 space-y-6">
+
+      <section>
+        <h2 class="text-lg mb-2">Contact</h2>
+        <% if @customer_email %>
+          <input type="email" value="<%= @customer_email %>" readonly
+                 class="input input-bordered w-full bg-gray-100"
+                 data-onsite-checkout-target="email">
+        <% else %>
+          <input type="email" placeholder="you@example.com" autocomplete="email"
+                 class="input input-bordered w-full"
+                 data-onsite-checkout-target="email"
+                 data-action="blur->onsite-checkout#emailChanged">
+        <% end %>
+      </section>
+
+      <section>
+        <h2 class="text-lg mb-2">Delivery address</h2>
+        <div data-onsite-checkout-target="address"></div>
+        <p class="text-sm text-error mt-2 hidden" data-onsite-checkout-target="zoneWarning">
+          This postcode is in a different delivery zone than your order was priced for.
+          <%= link_to "Return to your basket", cart_path, class: "link" %> to update your
+          delivery postcode and reprice.
+        </p>
+      </section>
+
+      <% if @show_promo %>
+        <section data-onsite-checkout-target="promoSection">
+          <h2 class="text-lg mb-2">Promo code</h2>
+          <div class="flex gap-2" data-onsite-checkout-target="promoForm">
+            <input type="text" placeholder="Enter code" class="input input-bordered input-sm flex-1"
+                   data-onsite-checkout-target="promoInput">
+            <button type="button" class="btn btn-sm btn-outline"
+                    data-action="onsite-checkout#applyPromo">Apply</button>
+          </div>
+          <div class="hidden items-center gap-2" data-onsite-checkout-target="promoApplied">
+            <span class="badge badge-success" data-onsite-checkout-target="promoCode"></span>
+            <button type="button" class="btn btn-xs btn-ghost"
+                    data-action="onsite-checkout#removePromo" aria-label="Remove promo code">&times;</button>
+          </div>
+          <p class="text-xs text-error mt-1 hidden" data-onsite-checkout-target="promoError"></p>
+        </section>
+      <% end %>
+
+      <section>
+        <h2 class="text-lg mb-2">Payment</h2>
+        <div data-onsite-checkout-target="payment"></div>
+      </section>
+
+      <p class="text-sm text-error hidden" data-onsite-checkout-target="error"></p>
+
+      <button type="button" class="btn btn-primary w-full" disabled
+              data-onsite-checkout-target="payButton"
+              data-action="onsite-checkout#pay">
+        Pay now
+      </button>
+
+      <noscript>
+        <p class="text-sm text-error">
+          Checkout needs JavaScript. <%= link_to "Return to your basket", cart_path, class: "link" %>.
+        </p>
+      </noscript>
+    </div>
+
+    <div class="w-full md:w-2/5">
+      <div class="bg-gray-100 p-4 sm:p-6 rounded-lg shadow-md">
+        <%= render "checkouts/summary", cart: Current.cart %>
+        <p class="mt-4 text-sm"><%= link_to "← Back to basket", cart_path, class: "link" %></p>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+`app/views/checkouts/_summary.html.erb` — reuses the cart's line source (`cart_summary_lines`, same as `cart_items/_summary`) but adds Stimulus targets so the SDK can re-render money lines after a promo code changes them:
+
+```erb
+<%# On-site checkout order summary. Lines come from cart_summary_lines (the same
+    source the cart page uses) for the initial server render; the money values
+    carry data targets so the onsite-checkout Stimulus controller re-renders
+    them from the Stripe session state (the charging authority) once the SDK is
+    live. Line KINDS map to targets; keep the kinds in step with CartSummary. %>
+<div id="checkout_summary">
+  <h2 class="text-lg sm:text-2xl mb-3 sm:mb-6">Order Summary</h2>
+
+  <% cart_summary_lines(cart).each do |line| %>
+    <% if line[:kind] == :total %>
+      <div class="flex justify-between text-lg sm:text-xl text-gray-800 border-t pt-3 mt-3">
+        <span><%= line[:label] %></span>
+        <span data-onsite-checkout-target="totalLine"><%= line[:amount] %></span>
+      </div>
+    <% else %>
+      <div class="flex justify-between mb-2 text-sm sm:text-base <%= line[:negative] ? "text-success" : "text-gray-700" %>">
+        <span><%= line[:label] %></span>
+        <span data-onsite-checkout-money-kind="<%= line[:kind] %>"><%= line[:amount] %></span>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+```
+
+(Check `app/helpers` for where `cart_summary_lines` and `cart_summary_line_dom_id` live and what `line[:kind]` values exist — mirror them; do NOT reuse the `#cart_summary` DOM id, which the cart page's Turbo Streams own.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/controllers/checkouts_controller.rb app/views/checkouts/show.html.erb app/views/checkouts/_summary.html.erb test/controllers/checkouts_controller_test.rb
+git commit -m "Render the on-site checkout page from the stashed session"
+```
+
+---
+
+### Task 7: Publishable key + CSP
+
+**Files:**
+- Modify: `config/initializers/stripe.rb` (or wherever `Rails.configuration.stripe` is assembled — grep `configuration.stripe` in `config/`)
+- Modify: `config/initializers/content_security_policy.rb`
+
+Nothing client-side ever needed the publishable key before (hosted checkout is a redirect), so it may not be wired.
+
+- [ ] **Step 1: Check and wire the publishable key**
+
+Run: `grep -rn "publishable" config/ app/ | grep -v node_modules`
+
+If `Rails.configuration.stripe[:publishable_key]` is not populated, add it where the stripe config hash is built (same pattern as `secret_key`, sourced from credentials — see `docs/runbooks/credentials.md` for the vault; sandbox and live keys differ). If the credentials key is missing, add it via `bin/rails credentials:edit` per the runbook and note it in the PR description.
+
+- [ ] **Step 2: Assert it in a test**
+
+Add to `test/controllers/checkouts_controller_test.rb`'s "show renders the page from a fresh stash" test:
+
+```ruby
+    assert_select "[data-onsite-checkout-publishable-key-value]" do |elements|
+      assert elements.first["data-onsite-checkout-publishable-key-value"].present?,
+        "publishable key must reach the page"
+    end
+```
+
+Run: `bin/rails test test/controllers/checkouts_controller_test.rb` — PASS (fix config until it does).
+
+- [ ] **Step 3: CSP additions**
+
+In `config/initializers/content_security_policy.rb` (currently report-only, so this can't break production, but must be right before the flag flips):
+
+```ruby
+    policy.script_src :self,
+                      :unsafe_inline,
+                      :unsafe_eval,
+                      "https://js.stripe.com",
+                      ... (existing entries unchanged)
+
+    policy.connect_src :self,
+                       "https://api.stripe.com",
+                       ... (existing entries unchanged)
+
+    policy.frame_src :self,
+                     "https://js.stripe.com",
+                     "https://hooks.stripe.com",
+                     ... (existing entries unchanged)
+```
+
+(Per Stripe's CSP documentation for Stripe.js/Elements: `script-src js.stripe.com`, `frame-src js.stripe.com hooks.stripe.com`, `connect-src api.stripe.com`. Verify against https://docs.stripe.com/security/guide#content-security-policy at implementation time and add any host the report-only console flags on staging.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/initializers/content_security_policy.rb config/initializers/stripe.rb test/controllers/checkouts_controller_test.rb
+git commit -m "Expose Stripe publishable key and allow Stripe hosts in CSP"
+```
+
+---
+
+### Task 8: Stimulus controller (SDK wiring)
+
+**Files:**
+- Create: `app/frontend/javascript/controllers/onsite_checkout_controller.js`
+- Modify: `app/frontend/entrypoints/application.js` (lazy-register)
+
+No JS test framework exists in this repo; this task is verified by Task 9's system test (markup + controller connects) and the staging checklist (real payments). Keep ALL SDK knowledge in this one file.
+
+**API verification step is part of this task:** the code below targets Stripe.js's checkout SDK ("Elements with Checkout Sessions API", `stripe.initCheckout`) as documented at https://docs.stripe.com/checkout/custom/quickstart and https://docs.stripe.com/js/custom_checkout. Before writing, open those pages and verify these exact names: `initCheckout`, `createPaymentElement`, `createShippingAddressElement`, `session()`, `on("change")`, `updateEmail`, `applyPromotionCode`, `removePromotionCode`, `confirm`, and the shape of `session.total`. Where a name differs, follow the docs — the structure below stands.
+
+- [ ] **Step 1: Write the controller**
+
+```js
+// app/frontend/javascript/controllers/onsite_checkout_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+// On-site checkout: binds the page to a Stripe Checkout Session (ui_mode:
+// "custom") created server-side. Stripe's SDK owns the money math; this
+// controller mounts the secure elements, mirrors session totals into the
+// summary, applies/removes promo codes, guards the shipping zone, and confirms.
+export default class extends Controller {
+  static targets = [
+    "email", "address", "payment", "payButton", "error",
+    "totalLine", "zoneWarning",
+    "promoSection", "promoForm", "promoInput", "promoApplied", "promoCode", "promoError"
+  ]
+
+  static values = {
+    clientSecret: String,
+    publishableKey: String,
+    pricedZone: String,
+    guest: Boolean,
+    prefill: Object
+  }
+
+  async connect() {
+    this.zoneOk = true
+    this.currency = new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" })
+
+    if (!window.Stripe) return this.fatal()
+
+    try {
+      this.stripe = Stripe(this.publishableKeyValue)
+      this.checkout = await this.stripe.initCheckout({
+        fetchClientSecret: async () => this.clientSecretValue
+      })
+    } catch (error) {
+      console.error("[onsite-checkout] init failed:", error)
+      return this.fatal()
+    }
+
+    this.checkout.createPaymentElement().mount(this.paymentTarget)
+
+    const addressOptions = Object.keys(this.prefillValue || {}).length
+      ? { defaultValues: this.prefillValue }
+      : {}
+    this.checkout.createShippingAddressElement(addressOptions).mount(this.addressTarget)
+
+    this.checkout.on("change", (session) => this.sessionChanged(session))
+    this.sessionChanged(this.checkout.session())
+    this.payButtonTarget.disabled = false
+  }
+
+  // --- session state → page ---
+
+  sessionChanged(session) {
+    this.renderTotals(session)
+    this.guardZone(session)
+  }
+
+  renderTotals(session) {
+    // session.total amounts are in minor units (pence). Update the grand total
+    // always; per-kind lines update when the session exposes a matching amount.
+    // Verify the exact session.total shape against the SDK docs (see task
+    // header); adjust ONLY the mapping below if key names differ.
+    if (session?.total?.total != null) {
+      this.totalLineTarget.textContent = this.currency.format(session.total.total / 100)
+    }
+    const kinds = {
+      subtotal: session?.total?.subtotal,
+      discount: session?.total?.discount,
+      vat: session?.total?.taxExclusive
+    }
+    for (const [kind, amount] of Object.entries(kinds)) {
+      if (amount == null) continue
+      const el = this.element.querySelector(`[data-onsite-checkout-money-kind='${kind}']`)
+      if (el) el.textContent = this.currency.format(amount / 100)
+    }
+  }
+
+  // --- zone guard (best-effort; any failure fails open) ---
+
+  guardZone(session) {
+    const postcode = session?.shippingAddress?.address?.postal_code
+    if (!postcode) return
+
+    clearTimeout(this.zoneTimer)
+    this.zoneTimer = setTimeout(() => this.checkZone(postcode), 400)
+  }
+
+  async checkZone(postcode) {
+    try {
+      const response = await fetch(`/shipping_zone?postcode=${encodeURIComponent(postcode)}`)
+      if (!response.ok) return
+      const { zone } = await response.json()
+      this.zoneOk = zone === this.pricedZoneValue
+    } catch {
+      this.zoneOk = true // fail open: no worse than hosted checkout today
+    }
+    this.zoneWarningTarget.classList.toggle("hidden", this.zoneOk)
+    this.payButtonTarget.disabled = !this.zoneOk
+  }
+
+  // --- email (guests only; logged-in email is read-only and already on the session) ---
+
+  async emailChanged() {
+    if (!this.guestValue) return
+    const email = this.emailTarget.value.trim()
+    if (!email) return
+    try {
+      await this.checkout.updateEmail(email)
+    } catch (error) {
+      this.showError("Please check your email address.")
+    }
+  }
+
+  // --- promo codes ---
+
+  async applyPromo() {
+    const code = this.promoInputTarget.value.trim()
+    if (!code) return
+    this.promoErrorTarget.classList.add("hidden")
+    const result = await this.checkout.applyPromotionCode(code)
+    if (result?.error) {
+      this.promoErrorTarget.textContent = result.error.message || "That code didn't work."
+      this.promoErrorTarget.classList.remove("hidden")
+      return
+    }
+    this.promoCodeTarget.textContent = code.toUpperCase()
+    this.promoFormTarget.classList.add("hidden")
+    this.promoAppliedTarget.classList.remove("hidden")
+    this.promoAppliedTarget.classList.add("flex")
+  }
+
+  async removePromo() {
+    await this.checkout.removePromotionCode()
+    this.promoAppliedTarget.classList.add("hidden")
+    this.promoAppliedTarget.classList.remove("flex")
+    this.promoFormTarget.classList.remove("hidden")
+    this.promoInputTarget.value = ""
+  }
+
+  // --- confirm ---
+
+  async pay() {
+    if (!this.zoneOk) return
+    this.payButtonTarget.disabled = true
+    this.errorTarget.classList.add("hidden")
+
+    const result = await this.checkout.confirm()
+    // On success Stripe redirects to return_url; we only come back here on error.
+    if (result?.error) {
+      this.showError(result.error.message || "Payment failed. Please try again.")
+      this.payButtonTarget.disabled = false
+    }
+  }
+
+  // --- errors ---
+
+  showError(message) {
+    this.errorTarget.textContent = message
+    this.errorTarget.classList.remove("hidden")
+  }
+
+  fatal() {
+    this.showError("Checkout couldn't load. Please refresh, or return to your basket and try again.")
+  }
+}
+```
+
+- [ ] **Step 2: Register it lazily**
+
+In `app/frontend/entrypoints/application.js`, add to the `lazyControllers` map (alphabetical position, matching the file's style):
+
+```js
+  "onsite-checkout": () => import("../javascript/controllers/onsite_checkout_controller"),
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `bin/vite build` (or `bin/dev` and load any page watching the console)
+Expected: build succeeds, no import errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/frontend/javascript/controllers/onsite_checkout_controller.js app/frontend/entrypoints/application.js
+git commit -m "Wire the on-site checkout page to Stripe's checkout SDK"
+```
+
+---
+
+### Task 9: System test
+
+**Files:**
+- Create: `test/system/onsite_checkout_page_test.rb`
+
+Per the spec: assert the page renders with summary, mount points, and promo control. Do NOT drive the real Stripe iframe in CI (flaky by design); confirm-and-pay is the staging checklist's job. System tests run the app in-process, so Mocha stubs apply.
+
+- [ ] **Step 1: Write the test**
+
+```ruby
+# test/system/onsite_checkout_page_test.rb
+require "application_system_test_case"
+
+class OnsiteCheckoutPageTest < ApplicationSystemTestCase
+  setup do
+    OnsiteCheckout.stubs(:enabled?).returns(true)
+    Stripe::TaxRate.stubs(:list).returns(stub(data: [ stub(id: "txr_test", percentage: 20.0) ]))
+    Stripe::Checkout::Session.stubs(:create).returns(
+      stub(id: "sess_custom_sys", url: nil, client_secret: "cs_test_secret_sys", payment_status: "unpaid")
+    )
+  end
+
+  test "checkout page renders summary, mount points, and promo control" do
+    visit product_path(products(:one))          # adjust to the real product path helper
+    click_on "Add to cart"                       # adjust to the real button label
+    visit cart_path
+    fill_in "Delivery postcode", with: "WD18 9SB"
+    click_on "Calculate shipping"
+    click_on "Checkout"                          # adjust to the real checkout button label
+
+    assert_current_path checkout_path
+    assert_selector "#checkout_summary"
+    assert_selector "[data-onsite-checkout-target='payment']"
+    assert_selector "[data-onsite-checkout-target='address']"
+    assert_selector "[data-onsite-checkout-target='promoSection']"
+    assert_selector "[data-onsite-checkout-target='payButton']"
+    assert_link "Back to basket"
+  end
+end
+```
+
+Before running: open the cart page views to confirm the real labels for the add-to-cart and checkout buttons and the product path helper, and adjust the three marked lines. If `StripeTestHelper` works in system tests (it's included via `test/support`), prefer `stub_stripe_tax_rate_list` + `build_custom_stripe_session` over the inline stubs above.
+
+- [ ] **Step 2: Run it**
+
+Run: `bin/rails test:system test/system/onsite_checkout_page_test.rb`
+Expected: PASS. (The Stimulus controller will attempt `initCheckout` against the fake secret and fail in the browser console — the test only asserts server-rendered markup, so that's fine.)
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `bin/rails test && bin/rails test:system`
+Expected: PASS across the board.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/system/onsite_checkout_page_test.rb
+git commit -m "Add system test for the on-site checkout page render"
+```
+
+---
+
+### Task 10: Developer guide + rollout checklist
+
+**Files:**
+- Modify: `docs/developer_guide.md` (the "Checkout & Orders" section, ~lines 282–360)
+
+- [ ] **Step 1: Rewrite the stale section**
+
+The current section shows a `shipping_options`-based flow (£4.99/£9.99) that predates zones and doesn't match `Checkout::SessionBuilder`. Replace it with an accurate description covering: `Checkout::SessionBuilder` (line items with the prepended taxed shipping line, `ShippingZone` pricing from the cart-page postcode, discounts via promotion-code resolution, `allow_promotion_codes` on the no-code path); the two ui_modes (hosted redirect vs on-site PRG flow: `#create` → stash + fingerprint → `GET /checkout` → Stripe custom-UI SDK → `return_url` to `#success`); the `OnsiteCheckout` ENV flag; and a pointer to the spec and ADR 0001. Pull code snippets from the REAL files, not from memory.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/developer_guide.md
+git commit -m "Rewrite developer guide checkout section for zones and on-site mode"
+```
+
+- [ ] **Step 3: Rollout checklist** (record in the PR description; these are ops steps, not code)
+
+1. Register **afida.com** and the staging domain for Apple Pay in the Stripe dashboard — **sandbox AND live**. A missed live registration silently hides the wallet button; nothing errors.
+2. Confirm `stripe.publishable_key` exists in BOTH sandbox and live credentials.
+3. Staging (`ONSITE_CHECKOUT=true`, Stripe sandbox) — full manual checklist from the spec: card; Apple Pay; Link; welcome discount; shopper-typed promo code; invalid promo code; 100%-off code (zero total, `no_payment_required`); samples-only cart (shipping charged, no promo control); off-mainland postcode priced at £25; zone-mismatch guard (price mainland on cart, type a Highlands postcode on the page → pay disabled, warning shown); declined card (4000 0000 0000 0002); `collected_information` present on the resulting order; refresh and back-button on the checkout page; totals match Stripe's charged amounts after a promo code. Watch the browser console for CSP report-only violations and add any missing Stripe hosts.
+4. Production: set `ONSITE_CHECKOUT=true`, deploy per `docs/runbooks/deploying.md` (boot by version, verify served HTML). First real order: verify the order record, emails, Telegram notification, and Datafast attribution.
+5. Rollback at any point: unset `ONSITE_CHECKOUT`, redeploy. Hosted checkout is untouched by every task above.
+
+---
+
+## Out of scope (per spec — do not build)
+
+Cart editing on the checkout page; shipping-method choice; order notes/custom fields; BNPL; Express Checkout Element; repricing shipping on the page; any change to `#success`, `OrderCreator`, the webhook handler, emails, or events.

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -118,6 +118,78 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:onsite_checkout]
   end
 
+  # --- GET /checkout (on-site page) ---
+
+  def stash_onsite_session
+    enable_onsite_checkout
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+    post checkout_path
+    assert_redirected_to checkout_path
+  end
+
+  test "show renders the page from a fresh stash" do
+    stash_onsite_session
+
+    get checkout_path
+
+    assert_response :success
+    assert_match "cs_test_secret_abc", response.body
+    assert_select "[data-controller='onsite-checkout']"
+    assert_select "[data-onsite-checkout-target='payment']"
+    assert_select "[data-onsite-checkout-target='address']"
+    assert_select "[data-onsite-checkout-publishable-key-value]" do |elements|
+      assert elements.first["data-onsite-checkout-publishable-key-value"].present?,
+        "publishable key must reach the page"
+    end
+  end
+
+  test "show redirects to cart when the flag is off" do
+    get checkout_path
+    assert_redirected_to cart_path
+  end
+
+  test "show redirects to cart without a stash" do
+    enable_onsite_checkout
+    get checkout_path
+    assert_redirected_to cart_path
+  end
+
+  test "show bounces a stale stash to the cart and discards it" do
+    stash_onsite_session
+
+    @cart.cart_items.first.update!(quantity: 5)
+
+    get checkout_path
+
+    assert_redirected_to cart_path
+    assert_equal "Your basket changed. Continue to payment when you're ready.", flash[:notice]
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show shows the promo control only when no server discount and not samples-only" do
+    stash_onsite_session
+    get checkout_path
+    assert_select "[data-onsite-checkout-target='promoSection']"
+  end
+
+  test "invalid welcome coupon renders the alert AND the promo control together" do
+    # The spec's pinned combination: #create fell back to allow_promotion_codes
+    # and deleted the session discount, so the GET page must show the failure
+    # alert while still offering the promo input (the shopper can retype).
+    enable_onsite_checkout
+    post email_subscriptions_path, params: { email: "promo-test@example.com" }
+    Stripe::PromotionCode.stubs(:list).returns(stub(data: []))
+    Stripe::Coupon.stubs(:retrieve).raises(Stripe::InvalidRequestError.new("No such coupon", nil))
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+
+    post checkout_path
+    follow_redirect!
+
+    assert_response :success
+    assert_match "Your discount code could not be applied", response.body
+    assert_select "[data-onsite-checkout-target='promoSection']"
+  end
+
   # ============================================================================
   # CREATE ACTION TESTS (POST /checkouts)
   # ============================================================================

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -54,6 +54,70 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
       .returns(stub(data: [ stub(id: WELCOME_PROMOTION_CODE_ID, code: WELCOME_PROMOTION_CODE) ]))
   end
 
+  # The controller tests stub the flag seam; OnsiteCheckout's own ENV parsing
+  # is covered in test/models/onsite_checkout_test.rb.
+  def enable_onsite_checkout
+    OnsiteCheckout.stubs(:enabled?).returns(true)
+  end
+
+  # ============================================================================
+  # ON-SITE CHECKOUT (flag on)
+  # ============================================================================
+
+  test "create with flag on builds a custom-mode session and redirects to the checkout page" do
+    enable_onsite_checkout
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_custom_stripe_session)
+
+    post checkout_path
+
+    assert_redirected_to checkout_path
+    assert_response :see_other
+    assert_equal "custom", captured_params[:ui_mode]
+    assert_match %r{/checkout/success\?session_id=\{CHECKOUT_SESSION_ID\}}, captured_params[:return_url]
+    assert_nil captured_params[:success_url]
+
+    stash = session[:onsite_checkout]
+    assert_equal "sess_custom_123", stash["session_id"]
+    assert_equal "cs_test_secret_abc", stash["client_secret"]
+    assert_equal "mainland", stash["zone"]
+    assert stash["fingerprint"].present?
+    assert_equal "WD18 9SB", stash["postcode"]
+  end
+
+  test "create with flag on still refuses an empty cart" do
+    enable_onsite_checkout
+    @cart.cart_items.destroy_all
+
+    post checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "create with flag on still refuses an undeliverable destination" do
+    enable_onsite_checkout
+    set_delivery_postcode("IM1 1AA")
+
+    post checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "create with flag off never stashes" do
+    stub_stripe_session_create
+
+    post checkout_path
+
+    assert_match %r{https://checkout\.stripe\.com}, response.redirect_url
+    assert_nil session[:onsite_checkout]
+  end
+
   # ============================================================================
   # CREATE ACTION TESTS (POST /checkouts)
   # ============================================================================

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -82,11 +82,14 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_nil captured_params[:success_url]
 
     stash = session[:onsite_checkout]
-    assert_equal "sess_custom_123", stash["session_id"]
     assert_equal "cs_test_secret_abc", stash["client_secret"]
     assert_equal "mainland", stash["zone"]
     assert stash["fingerprint"].present?
-    assert_equal "WD18 9SB", stash["postcode"]
+    assert_kind_of Integer, stash["created_at"]
+    # The stash is cookie payload on every request: only members #show actually
+    # reads belong in it.
+    assert_nil stash["session_id"]
+    assert_nil stash["postcode"]
   end
 
   test "create with flag on still refuses an empty cart" do
@@ -103,7 +106,7 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     enable_onsite_checkout
     # No typed postcode and no saved address to fall back to (an undeliverable
     # typed postcode is deleted by the cart action, so the fallback chain is
-    # what actually decides — same setup as the hosted guard tests).
+    # what actually decides; same setup as the hosted guard tests).
     @user.addresses.destroy_all
     set_delivery_postcode("")
     Stripe::Checkout::Session.expects(:create).never
@@ -121,6 +124,39 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
 
     assert_match %r{https://checkout\.stripe\.com}, response.redirect_url
     assert_nil session[:onsite_checkout]
+  end
+
+  # --- preview query param (env flag off throughout; no enabled? stub) ---
+
+  test "onsite_checkout=1 on any page enables the on-site checkout for the session" do
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+
+    get cart_path(onsite_checkout: "1")
+    post checkout_path
+
+    assert_redirected_to checkout_path
+    assert session[:onsite_checkout].present?
+  end
+
+  test "onsite_checkout=0 turns the preview back off" do
+    stub_stripe_session_create
+
+    get cart_path(onsite_checkout: "1")
+    get cart_path(onsite_checkout: "0")
+    post checkout_path
+
+    assert_match %r{https://checkout\.stripe\.com}, response.redirect_url
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show keeps serving a preview session while the env flag is off" do
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+    get cart_path(onsite_checkout: "1")
+    post checkout_path
+
+    get checkout_path
+
+    assert_response :success
   end
 
   # --- GET /checkout (on-site page) ---
@@ -146,6 +182,9 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
       assert elements.first["data-onsite-checkout-publishable-key-value"].present?,
         "publishable key must reach the page"
     end
+    # A hidden placeholder discount row so an on-page promo code has a row to
+    # unhide.
+    assert_select "div.hidden[data-onsite-checkout-target='discountRow']", count: 1
   end
 
   test "show redirects to cart when the flag is off" do
@@ -193,6 +232,102 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match "Your discount code could not be applied", response.body
     assert_select "[data-onsite-checkout-target='promoSection']"
+  end
+
+  test "show bounces the stash when the delivery postcode is removed after create" do
+    # The cart owner's saved addresses must not supply a fallback destination,
+    # or removal would just re-resolve to the default address.
+    @user.addresses.destroy_all
+    stash_onsite_session
+
+    set_delivery_postcode("")
+
+    get checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show prices the summary from the address the session was priced from" do
+    post session_url, params: { email_address: @user.email_address, password: "password" }
+    highlands = @user.addresses.create!(
+      nickname: "Croft", recipient_name: "John Smith", line1: "1 Shore Road",
+      city: "Portree", postcode: "IV51 9XX", country: "GB"
+    )
+    set_delivery_postcode("")
+    enable_onsite_checkout
+    Stripe::Customer.stubs(:create).returns(stub(id: "cus_highlands"))
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+
+    post checkout_path, params: { address_id: highlands.id }
+    assert_redirected_to checkout_path
+
+    get checkout_path
+
+    assert_response :success
+    # The Stripe session carries the Highlands £25 shipping line; the summary
+    # must show the same, not the default address's mainland price.
+    assert_select "[data-onsite-checkout-money-kind='shipping']", text: "£25.00"
+  end
+
+  test "show bounces an expired stash instead of re-serving a dead client secret" do
+    stash_onsite_session
+
+    travel 24.hours do
+      get checkout_path
+
+      assert_redirected_to cart_path
+      assert_match "expired", flash[:notice]
+    end
+
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show with the flag off discards the stash" do
+    stash_onsite_session
+    OnsiteCheckout.stubs(:enabled?).returns(false)
+
+    get checkout_path
+
+    assert_redirected_to cart_path
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "show renders the server discount row with the re-render target" do
+    enable_onsite_checkout
+    stub_welcome_promotion_code
+    post email_subscriptions_path, params: { email: "promo-row@example.com" }
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+
+    post checkout_path
+    get checkout_path
+
+    assert_response :success
+    assert_select "div.flex[data-onsite-checkout-target='discountRow']", count: 1
+  end
+
+  test "success clears the on-site checkout stash" do
+    stash_onsite_session
+    stripe_session = stub_stripe_session_retrieve(payment_status: "paid")
+
+    get success_checkout_path, params: { session_id: stripe_session.id }
+
+    assert_nil session[:onsite_checkout]
+  end
+
+  test "success logs the payment method that actually paid, not the configured list" do
+    captured = nil
+    stripe_session = build_stripe_session(payment_status: "paid", payment_method_type: "link")
+    Stripe::Checkout::Session.stubs(:retrieve).with do |params|
+      captured = params
+      true
+    end.returns(stripe_session)
+
+    assert_event_reported("checkout.completed", payload: { payment_method: "link" }) do
+      get success_checkout_path, params: { session_id: stripe_session.id }
+    end
+
+    assert_includes captured[:expand], "payment_intent.payment_method"
   end
 
   # ============================================================================
@@ -529,7 +664,7 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
       ]
     )
     Stripe::Checkout::Session.expects(:retrieve).with do |args|
-      args[:expand] == [ "collected_information", "line_items.data.price.product" ]
+      args[:expand] == [ "collected_information", "line_items.data.price.product", "payment_intent.payment_method" ]
     end.returns(session)
 
     assert_difference "Order.count", 1 do

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -99,9 +99,14 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:onsite_checkout]
   end
 
-  test "create with flag on still refuses an undeliverable destination" do
+  test "create with flag on still refuses an unknown destination" do
     enable_onsite_checkout
-    set_delivery_postcode("IM1 1AA")
+    # No typed postcode and no saved address to fall back to (an undeliverable
+    # typed postcode is deleted by the cart action, so the fallback chain is
+    # what actually decides — same setup as the hosted guard tests).
+    @user.addresses.destroy_all
+    set_delivery_postcode("")
+    Stripe::Checkout::Session.expects(:create).never
 
     post checkout_path
 

--- a/test/controllers/shipping_zones_controller_test.rb
+++ b/test/controllers/shipping_zones_controller_test.rb
@@ -26,6 +26,16 @@ class ShippingZonesControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ "zone" => "unknown", "deliverable" => false }, response.parsed_body)
   end
 
+  test "does not create a cart row for a cookieless client" do
+    # The route sits outside checkout's rate limit, so a cookieless client
+    # (bot, crawler) must not write an orphan Cart row per hit.
+    assert_no_difference "Cart.count" do
+      get shipping_zone_path, params: { postcode: "WD18 9SB" }
+    end
+
+    assert_response :success
+  end
+
   test "works logged out" do
     get shipping_zone_path, params: { postcode: "SW1A 1AA" }
 

--- a/test/controllers/shipping_zones_controller_test.rb
+++ b/test/controllers/shipping_zones_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ShippingZonesControllerTest < ActionDispatch::IntegrationTest
+  test "resolves a mainland postcode" do
+    get shipping_zone_path, params: { postcode: "WD18 9SB" }
+
+    assert_response :success
+    assert_equal({ "zone" => "mainland", "deliverable" => true }, response.parsed_body)
+  end
+
+  test "resolves a highlands postcode" do
+    get shipping_zone_path, params: { postcode: "IV51 9XX" }
+
+    assert_equal "highlands", response.parsed_body["zone"]
+  end
+
+  test "resolves an outward code alone, as the cart field does" do
+    get shipping_zone_path, params: { postcode: "BT1" }
+
+    assert_equal({ "zone" => "northern_ireland", "deliverable" => true }, response.parsed_body)
+  end
+
+  test "unparseable postcode is unknown and not deliverable" do
+    get shipping_zone_path, params: { postcode: "banana" }
+
+    assert_equal({ "zone" => "unknown", "deliverable" => false }, response.parsed_body)
+  end
+
+  test "works logged out" do
+    get shipping_zone_path, params: { postcode: "SW1A 1AA" }
+
+    assert_response :success
+  end
+end

--- a/test/controllers/webhooks/stripe_controller_test.rb
+++ b/test/controllers/webhooks/stripe_controller_test.rb
@@ -454,7 +454,7 @@ class Webhooks::StripeControllerTest < ActionDispatch::IntegrationTest
     event = build_stripe_webhook_event(type: "checkout.session.completed", data_object: session)
     stub_stripe_webhook_construct_event(event)
     Stripe::Checkout::Session.expects(:retrieve).with do |args|
-      args[:expand] == [ "collected_information", "line_items.data.price.product" ]
+      args[:expand] == [ "collected_information", "line_items.data.price.product", "payment_intent.payment_method" ]
     end.returns(session)
 
     assert_difference "Order.count", 1 do

--- a/test/integration/checkout_address_prefill_test.rb
+++ b/test/integration/checkout_address_prefill_test.rb
@@ -169,6 +169,21 @@ class CheckoutAddressPrefillTest < ActionDispatch::IntegrationTest
     assert_nil @captured_checkout_params[:customer]
   end
 
+  test "checkout without address_id clears a previously selected address" do
+    Stripe::Customer.stubs(:create).returns(stub(id: "cus_test_clear"))
+    Stripe::Checkout::Session.stubs(:create).returns(stub(url: "https://checkout.stripe.com/test/sess_clear"))
+
+    post checkout_path, params: { address_id: @address.id }
+    assert_equal @address.id.to_s, session[:selected_address_id]
+
+    # A later checkout with no selection (e.g. from the cart drawer) must not
+    # inherit the stale one: the on-site page would prefill and zone-guard an
+    # address this checkout wasn't priced from.
+    post checkout_path
+
+    assert_nil session[:selected_address_id]
+  end
+
   test "guest checkout does not store address selection" do
     sign_out
     # The stubbed @cart (from setup) stands in as the non-empty cart; signed out,

--- a/test/models/onsite_checkout_test.rb
+++ b/test/models/onsite_checkout_test.rb
@@ -19,4 +19,19 @@ class OnsiteCheckoutTest < ActiveSupport::TestCase
       assert_not OnsiteCheckout.enabled?, "expected #{value.inspect} to disable"
     end
   end
+
+  test "a session preview flag enables with the env flag off" do
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(nil)
+    assert OnsiteCheckout.enabled?({ "onsite_checkout_preview" => true })
+  end
+
+  test "a session without the preview flag does not enable" do
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(nil)
+    assert_not OnsiteCheckout.enabled?({})
+  end
+
+  test "the env flag enables regardless of the session" do
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns("true")
+    assert OnsiteCheckout.enabled?({})
+  end
 end

--- a/test/models/onsite_checkout_test.rb
+++ b/test/models/onsite_checkout_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class OnsiteCheckoutTest < ActiveSupport::TestCase
+  test "disabled when ONSITE_CHECKOUT is unset" do
+    ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(nil)
+    assert_not OnsiteCheckout.enabled?
+  end
+
+  test "enabled for truthy values" do
+    %w[true 1].each do |value|
+      ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(value)
+      assert OnsiteCheckout.enabled?, "expected #{value.inspect} to enable"
+    end
+  end
+
+  test "disabled for falsy or junk values" do
+    [ "false", "0", "", "banana" ].each do |value|
+      ENV.stubs(:[]).with("ONSITE_CHECKOUT").returns(value)
+      assert_not OnsiteCheckout.enabled?, "expected #{value.inspect} to disable"
+    end
+  end
+end

--- a/test/models/shipping_zone_test.rb
+++ b/test/models/shipping_zone_test.rb
@@ -210,6 +210,12 @@ class ShippingZoneTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalise is the canonical form of a typed postcode" do
+    # Shared with Checkout::CartFingerprint, so "the same postcode" means the
+    # same thing to the zone resolver and to the staleness fingerprint.
+    assert_equal "IV51 9XX", ShippingZone.normalise(" iv51  9xx ")
+  end
+
   test "handles messy real-world input" do
     # Bt618he is a real production postcode: no space, mixed case.
     assert_equal :northern_ireland, ShippingZone.for("Bt618he")

--- a/test/services/cart_summary_test.rb
+++ b/test/services/cart_summary_test.rb
@@ -152,6 +152,26 @@ class CartSummaryTest < ActiveSupport::TestCase
     assert non_discount.none? { |l| l[:negative] }, "only the discount line should be negative"
   end
 
+  # The on-site checkout page asks for a placeholder so a promo code applied
+  # on-page has a discount row to unhide; the cart surfaces never pass the
+  # option and keep their line set unchanged.
+  test "placeholder_discount emits a placeholder discount row when no discount is taken" do
+    lines = CartSummary.lines(@cart, placeholder_discount: true)
+
+    assert_equal %i[subtotal shipping discount vat total], lines.map { |l| l[:kind] }
+    discount = lines.find { |l| l[:kind] == :discount }
+    assert discount[:placeholder]
+  end
+
+  test "placeholder_discount leaves a real discount line as is" do
+    @cart.discount_rate = 0.10
+
+    discount = CartSummary.lines(@cart, placeholder_discount: true).find { |l| l[:kind] == :discount }
+
+    assert_not discount[:placeholder]
+    assert_equal "Discount (#{CartsHelper::WELCOME_DISCOUNT_PERCENTAGE}%)", discount[:label]
+  end
+
   private
 
   # A cart whose subtotal clears the free-shipping threshold, so mainland ships

--- a/test/services/checkout/cart_fingerprint_test.rb
+++ b/test/services/checkout/cart_fingerprint_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Checkout::CartFingerprintTest < ActiveSupport::TestCase
+  setup do
+    @cart = Cart.create!
+    @cart.cart_items.create!(product: products(:one), quantity: 2, price: 10.00)
+  end
+
+  def digest(cart: @cart, postcode: "WD18 9SB", discount_code: nil)
+    Checkout::CartFingerprint.digest(cart: cart, postcode: postcode, discount_code: discount_code)
+  end
+
+  test "stable for identical inputs" do
+    assert_equal digest, digest
+  end
+
+  test "changes when a quantity changes" do
+    before = digest
+    @cart.cart_items.first.update!(quantity: 3)
+    assert_not_equal before, digest
+  end
+
+  test "changes when an item is added" do
+    before = digest
+    @cart.cart_items.create!(product: products(:two), quantity: 1, price: 30.00)
+    assert_not_equal before, digest
+  end
+
+  test "changes when the postcode changes" do
+    assert_not_equal digest(postcode: "WD18 9SB"), digest(postcode: "IV51 9XX")
+  end
+
+  test "insensitive to postcode case and whitespace" do
+    assert_equal digest(postcode: "WD18 9SB"), digest(postcode: " wd18 9sb ")
+  end
+
+  test "changes when the discount code changes" do
+    assert_not_equal digest(discount_code: nil), digest(discount_code: "coupon_abc")
+  end
+end

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -7,6 +7,7 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
     @cart = Cart.create!
     @success_url = "https://example.com/checkout/success?session_id={CHECKOUT_SESSION_ID}"
     @cancel_url = "https://example.com/checkout/cancel"
+    @return_url = "https://example.com/checkout/success?session_id={CHECKOUT_SESSION_ID}"
     stub_stripe_tax_rate_list
   end
 
@@ -437,6 +438,73 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
 
   # The first non-shipping line item. The shipping line is now prepended, so
   # tests must select the product line by content rather than by position.
+  # --- custom (on-site) mode ---
+
+  test "custom mode differs from hosted only in ui_mode, URLs, and payment methods" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured = []
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured << params
+      true
+    end.returns(build_stripe_session)
+
+    build_session
+    build_custom_session
+
+    hosted, custom = captured
+
+    assert_equal "custom", custom[:ui_mode]
+    assert_equal @return_url, custom[:return_url]
+    assert_nil custom[:success_url]
+    assert_nil custom[:cancel_url]
+    assert_equal [ "card", "link" ], custom[:payment_method_types]
+
+    # Everything else must be identical - this is the parity contract the
+    # hosted fallback depends on. Shipping line item drift here costs money.
+    mode_keys = [ :ui_mode, :return_url, :success_url, :cancel_url, :payment_method_types ]
+    assert_equal hosted.except(*mode_keys), custom.except(*mode_keys)
+  end
+
+  test "custom mode pins the shipping line item exactly as hosted does" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_custom_session(delivery_postcode: "IV51 9XX")
+
+    shipping_line = shipping_line_item(captured_params)
+    assert_equal Shipping::LINE_ITEM_FLAG, shipping_line[:price_data][:product_data][:metadata]
+    assert_equal Shipping.cost_for_zone(:highlands), shipping_line[:price_data][:unit_amount]
+    assert_equal "highlands", captured_params[:metadata][:shipping_zone]
+  end
+
+  test "custom mode keeps allow_promotion_codes on the no-code path" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_custom_session
+
+    assert_equal true, captured_params[:allow_promotion_codes]
+  end
+
+  test "result exposes the priced zone" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+    Stripe::Checkout::Session.stubs(:create).returns(build_stripe_session)
+
+    assert_equal :highlands, build_session(delivery_postcode: "IV51 9XX").zone
+    assert_equal :mainland, build_session(delivery_postcode: "WD18 9SB").zone
+  end
+
   def product_line_item(captured_params)
     captured_params[:line_items].find do |li|
       li.dig(:price_data, :product_data, :metadata, "shipping_line") != "true"
@@ -449,11 +517,18 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
     end
   end
 
-  def build_session(discount_code: nil)
-    build_session_builder(discount_code: discount_code).create
+  def build_session(discount_code: nil, delivery_postcode: nil, ui_mode: :hosted, return_url: nil)
+    build_session_builder(
+      discount_code: discount_code, delivery_postcode: delivery_postcode,
+      ui_mode: ui_mode, return_url: return_url
+    ).create
   end
 
-  def build_session_builder(user: nil, address_id: nil, discount_code: nil, delivery_postcode: nil)
+  def build_custom_session(**kwargs)
+    build_session(ui_mode: :custom, return_url: @return_url, **kwargs)
+  end
+
+  def build_session_builder(user: nil, address_id: nil, discount_code: nil, delivery_postcode: nil, ui_mode: :hosted, return_url: nil)
     Checkout::SessionBuilder.new(
       cart: @cart,
       user: user,
@@ -463,7 +538,9 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
       datafast_visitor_id: nil,
       datafast_session_id: nil,
       success_url: @success_url,
-      cancel_url: @cancel_url
+      cancel_url: @cancel_url,
+      ui_mode: ui_mode,
+      return_url: return_url
     )
   end
 end

--- a/test/support/stripe_test_helper.rb
+++ b/test/support/stripe_test_helper.rb
@@ -79,6 +79,11 @@ module StripeTestHelper
       setup_intent = stub(id: "seti_test_#{SecureRandom.hex(12)}", payment_method: payment_method)
     end
 
+    # The payment method that actually paid, as the expanded payment_intent
+    # carries it (retrieve with expand: ["payment_intent.payment_method"]).
+    # Override with payment_method_type: "link" to model a Link payment.
+    payment_intent = stub(payment_method: stub(type: overrides[:payment_method_type] || "card"))
+
     # Build total_details for tax and discount information
     tax_amount = overrides[:amount_tax] || 0
     discount_amount = overrides[:amount_discount] || 0
@@ -146,6 +151,7 @@ module StripeTestHelper
       url: "https://checkout.stripe.com/test/#{session_id}",
       payment_status: overrides[:payment_status] || "paid",
       payment_method_types: overrides[:payment_method_types] || [ "card" ],
+      payment_intent: payment_intent,
       customer_details: customer_details,
       collected_information: collected_information,
       shipping_cost: shipping_cost,

--- a/test/support/stripe_test_helper.rb
+++ b/test/support/stripe_test_helper.rb
@@ -263,6 +263,17 @@ module StripeTestHelper
     session
   end
 
+  # Custom-mode (on-site checkout) session: no redirect URL, has a client
+  # secret for the on-site page to bind Stripe.js's checkout SDK to.
+  def build_custom_stripe_session
+    stub(
+      id: "sess_custom_123",
+      url: nil,
+      client_secret: "cs_test_secret_abc",
+      payment_status: "unpaid"
+    )
+  end
+
   # Stub Stripe::Checkout::Session.retrieve to return a session
   def stub_stripe_session_retrieve(session_overrides = {})
     session = build_stripe_session(session_overrides)

--- a/test/system/onsite_checkout_page_test.rb
+++ b/test/system/onsite_checkout_page_test.rb
@@ -1,0 +1,34 @@
+require "application_system_test_case"
+
+class OnsiteCheckoutPageTest < ApplicationSystemTestCase
+  include StripeTestHelper
+
+  setup do
+    OnsiteCheckout.stubs(:enabled?).returns(true)
+    stub_stripe_tax_rate_list
+    Stripe::Checkout::Session.stubs(:create).returns(build_custom_stripe_session)
+  end
+
+  # Per the spec: assert the page renders with summary, mount points, and promo
+  # control. Driving the real Stripe iframe in CI is flaky by design, so
+  # confirm-and-pay is covered manually on staging, not here.
+  test "checkout page renders summary, mount points, and promo control" do
+    visit product_path(products(:one).slug)
+    click_on "Add to Cart", match: :first
+
+    visit cart_path
+    fill_in "Delivery postcode", with: "WD18 9SB"
+    click_on "Calculate shipping"
+    click_on "Proceed to Checkout"
+
+    assert_current_path checkout_path
+    assert_selector "#checkout_summary"
+    # The element mounts are empty placeholder divs until Stripe.js fills them
+    # (it can't init against the stubbed secret here), so match invisible too.
+    assert_selector "[data-onsite-checkout-target='payment']", visible: :all
+    assert_selector "[data-onsite-checkout-target='address']", visible: :all
+    assert_selector "[data-onsite-checkout-target='promoSection']"
+    assert_selector "[data-onsite-checkout-target='payButton']"
+    assert_link "Back to basket"
+  end
+end


### PR DESCRIPTION
## Summary

Moves checkout onto afida.com instead of redirecting to Stripe's hosted page, behind the `ONSITE_CHECKOUT` env flag with instant hosted fallback. Stripe stays the money-math authority: the existing `Checkout::SessionBuilder` gains a `ui_mode: "custom"` mode whose params differ from hosted **only** in `ui_mode`/`return_url`/payment method types (pinned by a parity test); everything after payment — `#success`, `OrderCreator`, the webhook, zero-total handling — is untouched.

- Spec: `docs/superpowers/specs/2026-07-28-onsite-checkout-design.md`
- ADR: `docs/adr/0001-onsite-checkout-on-checkout-sessions.md`
- Plan (all steps checked off): `docs/superpowers/plans/2026-07-28-onsite-checkout.md`

### How it works

Flag on: `#create` keeps all guards/events/rate limit, builds the custom-mode session, stashes `{session_id, client_secret, fingerprint, postcode, zone}` in the Rails session, and 303-redirects to `GET /checkout` (refresh/back-safe, no Stripe writes on GET). A `Checkout::CartFingerprint` mismatch (cart/postcode/discount changed) bounces to the cart. The page mounts Stripe's Payment Element (cards + Apple/Google Pay + Link) and Shipping Address Element, offers an apply/remove promo control (hidden when the welcome discount applies or the cart is samples-only), prefills saved address with read-only email for logged-in users, and re-renders discount/VAT/total from the SDK session. A best-effort zone guard (`GET /shipping_zone`) blocks confirm when the typed postcode's zone differs from the priced zone, failing open to today's hosted behaviour.

### Test coverage

Full suite green: 2940 runs, 0 failures. New: flag unit tests, builder parity + shipping-line pinning, zone endpoint, fingerprint, PRG/stash/staleness controller tests (incl. the invalid-coupon alert + promo control combination), and a system test for the page render. Driving the real Stripe iframe in CI is intentionally out of scope.

## Rollout checklist (before flipping the flag)

- [ ] Register afida.com AND the staging domain for Apple Pay in the Stripe dashboard — sandbox and live (a missed live registration silently hides the wallet button)
- [ ] Confirm `stripe.publishable_key` in both sandbox and live credentials
- [ ] Staging with `ONSITE_CHECKOUT=true`: card; Apple Pay; Link; welcome discount; typed promo code; invalid promo; 100%-off (zero total); samples-only cart (shipping charged, no promo control); off-mainland postcode at £25; zone-mismatch guard; declined card (4000 0000 0000 0002); `collected_information` on the order; refresh/back on the page; totals match Stripe after a promo; watch console for CSP report-only violations
- [ ] Production: set `ONSITE_CHECKOUT=true`, deploy per `docs/runbooks/deploying.md`; verify first real order (record, emails, Telegram, Datafast attribution)
- [ ] Rollback at any point: unset `ONSITE_CHECKOUT`, redeploy — hosted checkout is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)