### PR TITLE
Collect and display the billing address alongside shipping

### DIFF
--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -88,9 +88,6 @@ module Webhooks
 
       # Extract shipping address
       shipping = Checkout::SessionDetails.shipping_address(full_session)
-      # {} when the session carries none (fail open, unlike shipping): billing
-      # is display-only, so its absence must never cost a paid order.
-      billing = Checkout::SessionDetails.billing_address(full_session)
 
       # Guard the permanent failure upstream (as OrderCreator does on the success
       # path): a completed session with no shipping_details would build an order with
@@ -140,18 +137,10 @@ module Webhooks
           discount_amount: discount_amount,
           discount_code: discount_code.presence,
           branded_order_status: (cart&.cart_items&.any?(&:configured?) ? "design_pending" : nil),
-          shipping_name: shipping[:name],
-          shipping_address_line1: shipping[:line1],
-          shipping_address_line2: shipping[:line2],
-          shipping_city: shipping[:city],
-          shipping_postal_code: shipping[:postal_code],
-          shipping_country: shipping[:country],
-          billing_name: billing[:name],
-          billing_address_line1: billing[:line1],
-          billing_address_line2: billing[:line2],
-          billing_city: billing[:city],
-          billing_postal_code: billing[:postal_code],
-          billing_country: billing[:country],
+          # Both addresses come from the shared mapping (billing fails open to
+          # nils); OrderCreator on the success path merges the same call so the
+          # two can't drift.
+          **Checkout::SessionDetails.order_address_attributes(full_session),
           # The zone the order was priced against (see SessionDetails), not the
           # zone of the collected address, so the order records what was charged.
           shipping_zone: Checkout::SessionDetails.shipping_zone(full_session)

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -88,6 +88,9 @@ module Webhooks
 
       # Extract shipping address
       shipping = Checkout::SessionDetails.shipping_address(full_session)
+      # {} when the session carries none (fail open, unlike shipping): billing
+      # is display-only, so its absence must never cost a paid order.
+      billing = Checkout::SessionDetails.billing_address(full_session)
 
       # Guard the permanent failure upstream (as OrderCreator does on the success
       # path): a completed session with no shipping_details would build an order with
@@ -143,6 +146,12 @@ module Webhooks
           shipping_city: shipping[:city],
           shipping_postal_code: shipping[:postal_code],
           shipping_country: shipping[:country],
+          billing_name: billing[:name],
+          billing_address_line1: billing[:line1],
+          billing_address_line2: billing[:line2],
+          billing_city: billing[:city],
+          billing_postal_code: billing[:postal_code],
+          billing_country: billing[:country],
           # The zone the order was priced against (see SessionDetails), not the
           # zone of the collected address, so the order records what was charged.
           shipping_zone: Checkout::SessionDetails.shipping_zone(full_session)

--- a/app/frontend/javascript/controllers/onsite_checkout_controller.js
+++ b/app/frontend/javascript/controllers/onsite_checkout_controller.js
@@ -15,7 +15,7 @@ import { Controller } from "@hotwired/stimulus"
 // discount, VAT, and total.
 export default class extends Controller {
   static targets = [
-    "email", "address", "payment", "payButton", "error",
+    "email", "address", "billingAddress", "payment", "payButton", "error",
     "totalLine", "discountRow", "zoneWarning",
     "promoSection", "promoForm", "promoInput", "promoApplied", "promoCode", "promoError"
   ]
@@ -37,7 +37,12 @@ export default class extends Controller {
       this.stripe = Stripe(this.publishableKeyValue)
       this.checkout = await this.stripe.initCheckoutElementsSdk({
         clientSecret: this.clientSecretValue,
-        defaultValues: this.defaultValues()
+        defaultValues: this.defaultValues(),
+        // Puts Stripe's "same as shipping" checkbox on the billing element so
+        // most shoppers never type their address twice. Documented as the
+        // default when both address elements share one Elements instance, but
+        // the clover SDK does not apply it unless set explicitly.
+        elementsOptions: { syncAddressCheckbox: "billing" }
       })
       // loadActions resolves to a {type, actions} result wrapper; the
       // callable actions (updateEmail, confirm, ...) live one level down.
@@ -57,6 +62,13 @@ export default class extends Controller {
     this.paymentElement.mount(this.paymentTarget)
     this.addressElement = this.checkout.createShippingAddressElement()
     this.addressElement.mount(this.addressTarget)
+    // The session sets billing_address_collection "required", and in custom
+    // mode the Payment Element does NOT collect billing: without this element
+    // canConfirm never turns true and the Pay button stays dead. Sharing the
+    // Elements instance with the shipping element gives it Stripe's own
+    // "same as shipping" checkbox (syncAddressCheckbox defaults to billing).
+    this.billingAddressElement = this.checkout.createBillingAddressElement()
+    this.billingAddressElement.mount(this.billingAddressTarget)
 
     this.checkout.on("change", (session) => this.sessionChanged(session))
     this.sessionChanged(this.actions.getSession())
@@ -69,7 +81,8 @@ export default class extends Controller {
     clearTimeout(this.zoneTimer)
     this.paymentElement?.destroy?.()
     this.addressElement?.destroy?.()
-    this.paymentElement = this.addressElement = null
+    this.billingAddressElement?.destroy?.()
+    this.paymentElement = this.addressElement = this.billingAddressElement = null
     this.checkout = this.actions = this.session = null
   }
 

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -22,19 +22,17 @@ module OrdersHelper
     OrderSummary.lines(order)
   end
 
-  # The order's addresses as ordered display lines, shared by the same surfaces
-  # as order_summary_lines. See OrderAddress for the billing rules (empty when
-  # none collected, a "Same as delivery address" note when identical).
+  # The order's addresses as ordered {kind:, text:} display lines, shared by
+  # the same surfaces as order_summary_lines. See OrderAddress for the line
+  # shape and the billing rules (empty when none collected, a "Same as
+  # delivery address" note when identical); gate billing blocks on
+  # order.billing_address? directly.
   def shipping_address_lines(order)
     OrderAddress.shipping_lines(order)
   end
 
   def billing_address_lines(order)
     OrderAddress.billing_lines(order)
-  end
-
-  def show_billing_address?(order)
-    order.billing_address?
   end
 
   # Our SKU for an order item, with the supplier SKU appended in parentheses when

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -22,6 +22,21 @@ module OrdersHelper
     OrderSummary.lines(order)
   end
 
+  # The order's addresses as ordered display lines, shared by the same surfaces
+  # as order_summary_lines. See OrderAddress for the billing rules (empty when
+  # none collected, a "Same as delivery address" note when identical).
+  def shipping_address_lines(order)
+    OrderAddress.shipping_lines(order)
+  end
+
+  def billing_address_lines(order)
+    OrderAddress.billing_lines(order)
+  end
+
+  def show_billing_address?(order)
+    order.billing_address?
+  end
+
   # Our SKU for an order item, with the supplier SKU appended in parentheses when
   # known, e.g. "VEG-CC-9-7 (R300S-VW)". Used in internal ops views so admins can
   # cross-reference our catalogue against a supplier's. Prefers the SKU snapshot

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -97,6 +97,31 @@ class Order < ApplicationRecord
     address_parts.join(", ")
   end
 
+  # Whether a billing address was recorded. Orders predating billing collection
+  # (and sessions where Stripe returned none) have nothing - display surfaces
+  # must render no billing block at all, not an empty one.
+  def billing_address?
+    billing_address_line1.present?
+  end
+
+  # Whether the billing address matches the delivery address, so display
+  # surfaces can show a "Same as delivery address" note instead of repeating
+  # the block. Deliberately IGNORES the name: Stripe populates billing_name
+  # (customer_details.name) independently of the shipping recipient (cardholder
+  # vs recipient, abbreviated vs full name), so including it would make the
+  # same-address case look different for most real orders. Plain string
+  # equality otherwise - a case or whitespace mismatch just renders a
+  # redundant-but-correct block.
+  def billing_same_as_shipping?
+    return false unless billing_address?
+
+    billing_address_line1 == shipping_address_line1 &&
+      billing_address_line2 == shipping_address_line2 &&
+      billing_city == shipping_city &&
+      billing_postal_code == shipping_postal_code &&
+      billing_country == shipping_country
+  end
+
   def display_number
     "##{order_number}"
   end

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -12,7 +12,7 @@ module Checkout
       end
 
       ApplicationRecord.transaction do
-        order = Order.create!(order_attributes(shipping_address))
+        order = Order.create!(order_attributes)
 
         cart_items.each do |cart_item|
           OrderItem.build_from_cart_item(cart_item, order).save!
@@ -26,11 +26,8 @@ module Checkout
 
     attr_reader :stripe_session, :cart
 
-    def order_attributes(shipping_address)
+    def order_attributes
       amounts = Checkout::SessionAmounts.from(stripe_session)
-      # {} when the session carries none (fail open, unlike shipping): billing
-      # is display-only, so its absence must never cost a paid order.
-      billing_address = Checkout::SessionDetails.billing_address(stripe_session)
       attributes = {
         user: user,
         organization: user&.organization,
@@ -44,18 +41,10 @@ module Checkout
         total_amount: amounts.total,
         discount_amount: amounts.discount,
         discount_code: discount_code.presence,
-        shipping_name: shipping_address[:name],
-        shipping_address_line1: shipping_address[:line1],
-        shipping_address_line2: shipping_address[:line2],
-        shipping_city: shipping_address[:city],
-        shipping_postal_code: shipping_address[:postal_code],
-        shipping_country: shipping_address[:country],
-        billing_name: billing_address[:name],
-        billing_address_line1: billing_address[:line1],
-        billing_address_line2: billing_address[:line2],
-        billing_city: billing_address[:city],
-        billing_postal_code: billing_address[:postal_code],
-        billing_country: billing_address[:country],
+        # Both addresses come from the shared mapping (billing fails open to
+        # nils - display-only, must never cost a paid order); the webhook path
+        # merges the same call so the two can't drift.
+        **Checkout::SessionDetails.order_address_attributes(stripe_session),
         # The zone the order was priced against, not the zone of the collected
         # address: the order records what the customer was charged. Nil falls
         # back to deriving from the postcode (see Order#delivery_zone).

--- a/app/services/checkout/order_creator.rb
+++ b/app/services/checkout/order_creator.rb
@@ -28,6 +28,9 @@ module Checkout
 
     def order_attributes(shipping_address)
       amounts = Checkout::SessionAmounts.from(stripe_session)
+      # {} when the session carries none (fail open, unlike shipping): billing
+      # is display-only, so its absence must never cost a paid order.
+      billing_address = Checkout::SessionDetails.billing_address(stripe_session)
       attributes = {
         user: user,
         organization: user&.organization,
@@ -47,6 +50,12 @@ module Checkout
         shipping_city: shipping_address[:city],
         shipping_postal_code: shipping_address[:postal_code],
         shipping_country: shipping_address[:country],
+        billing_name: billing_address[:name],
+        billing_address_line1: billing_address[:line1],
+        billing_address_line2: billing_address[:line2],
+        billing_city: billing_address[:city],
+        billing_postal_code: billing_address[:postal_code],
+        billing_country: billing_address[:country],
         # The zone the order was priced against, not the zone of the collected
         # address: the order records what the customer was charged. Nil falls
         # back to deriving from the postcode (see Order#delivery_zone).

--- a/app/services/checkout/session_builder.rb
+++ b/app/services/checkout/session_builder.rb
@@ -52,6 +52,11 @@ module Checkout
         shipping_address_collection: {
           allowed_countries: Shipping::ALLOWED_COUNTRIES
         },
+        # Stripe's default ("auto") collects only the fields the payment method
+        # needs, which for cards is a bare country dropdown; "required" makes
+        # both the hosted page and the custom-mode Payment Element collect the
+        # full billing address, persisted on the order as billing_*.
+        billing_address_collection: "required",
         metadata: {
           cart_id: cart.id.to_s,
           discount_code: discount_code,

--- a/app/services/checkout/session_details.rb
+++ b/app/services/checkout/session_details.rb
@@ -1,6 +1,6 @@
 module Checkout
   # The single home for deriving the non-money Order fields from a completed Stripe
-  # Checkout session: the shipping address and the promotion code. Both
+  # Checkout session: the shipping and billing addresses and the promotion code. Both
   # order-creation paths (Checkout::OrderCreator on the success redirect and the
   # Stripe webhook fallback) call these, so the two can't drift in how they read a
   # session. Money figures live in SessionAmounts; the required-field presence check
@@ -27,6 +27,36 @@ module Checkout
 
       {
         name: shipping[:name],
+        line1: address[:line1],
+        line2: address[:line2],
+        city: address[:city],
+        postal_code: address[:postal_code],
+        country: address[:country]
+      }
+    end
+
+    # Maps the session's customer details (name + address) to the billing_* hash the
+    # Order is built from, or {} when absent. Unlike shipping, billing does NOT live
+    # under collected_information: billing_address_collection populates
+    # customer_details on the completed session. Must fail open with no counterpart
+    # to Order.required_shipping_values - sessions predating billing collection,
+    # Link/wallet flows reusing a stored address, and zero-total sessions can all
+    # legitimately carry no billing address, and none of that may block an order
+    # the customer has already paid for.
+    def billing_address(session)
+      session_hash = session.to_hash.with_indifferent_access
+
+      customer_details = session_hash[:customer_details]
+      return {} unless customer_details
+
+      customer_details = customer_details.with_indifferent_access if customer_details.respond_to?(:with_indifferent_access)
+      address = customer_details[:address]
+      return {} unless address
+
+      address = address.with_indifferent_access if address.respond_to?(:with_indifferent_access)
+
+      {
+        name: customer_details[:name],
         line1: address[:line1],
         line2: address[:line2],
         city: address[:city],

--- a/app/services/checkout/session_details.rb
+++ b/app/services/checkout/session_details.rb
@@ -12,27 +12,10 @@ module Checkout
     # is built from, or {} when the session carries no shipping details (a permanent
     # failure both callers guard via Order.required_shipping_values). Uses
     # to_hash.with_indifferent_access for defensive hash access (Stripe objects nest
-    # inconsistently across API versions).
+    # inconsistently across API versions); with_indifferent_access deep-converts, so
+    # nested hashes need no further coercion.
     def shipping_address(session)
-      session_hash = session.to_hash.with_indifferent_access
-
-      shipping = session_hash.dig(:collected_information, :shipping_details)
-      return {} unless shipping
-
-      shipping = shipping.with_indifferent_access if shipping.respond_to?(:with_indifferent_access)
-      address = shipping[:address]
-      return {} unless address
-
-      address = address.with_indifferent_access if address.respond_to?(:with_indifferent_access)
-
-      {
-        name: shipping[:name],
-        line1: address[:line1],
-        line2: address[:line2],
-        city: address[:city],
-        postal_code: address[:postal_code],
-        country: address[:country]
-      }
+      shipping_address_from(session.to_hash.with_indifferent_access)
     end
 
     # Maps the session's customer details (name + address) to the billing_* hash the
@@ -44,19 +27,55 @@ module Checkout
     # legitimately carry no billing address, and none of that may block an order
     # the customer has already paid for.
     def billing_address(session)
-      session_hash = session.to_hash.with_indifferent_access
+      billing_address_from(session.to_hash.with_indifferent_access)
+    end
 
+    # Both addresses mapped to the Order's shipping_*/billing_* column names in
+    # one pass: the single source both order-creation paths merge into their
+    # Order.create! attributes, so a new address field can never be wired into
+    # the success redirect but forgotten on the webhook (or vice versa). One
+    # to_hash conversion covers both reads - the expanded session is large
+    # (line items, payment intent), so callers should not convert it twice.
+    def order_address_attributes(session)
+      session_hash = session.to_hash.with_indifferent_access
+      shipping = shipping_address_from(session_hash)
+      billing = billing_address_from(session_hash)
+
+      {
+        shipping_name: shipping[:name],
+        shipping_address_line1: shipping[:line1],
+        shipping_address_line2: shipping[:line2],
+        shipping_city: shipping[:city],
+        shipping_postal_code: shipping[:postal_code],
+        shipping_country: shipping[:country],
+        billing_name: billing[:name],
+        billing_address_line1: billing[:line1],
+        billing_address_line2: billing[:line2],
+        billing_city: billing[:city],
+        billing_postal_code: billing[:postal_code],
+        billing_country: billing[:country]
+      }
+    end
+
+    def shipping_address_from(session_hash)
+      shipping = session_hash.dig(:collected_information, :shipping_details)
+      return {} unless shipping
+
+      extract_address(name: shipping[:name], address: shipping[:address])
+    end
+
+    def billing_address_from(session_hash)
       customer_details = session_hash[:customer_details]
       return {} unless customer_details
 
-      customer_details = customer_details.with_indifferent_access if customer_details.respond_to?(:with_indifferent_access)
-      address = customer_details[:address]
+      extract_address(name: customer_details[:name], address: customer_details[:address])
+    end
+
+    def extract_address(name:, address:)
       return {} unless address
 
-      address = address.with_indifferent_access if address.respond_to?(:with_indifferent_access)
-
       {
-        name: customer_details[:name],
+        name: name,
         line1: address[:line1],
         line2: address[:line2],
         city: address[:city],

--- a/app/services/order_address.rb
+++ b/app/services/order_address.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# The order's shipping and billing addresses as ordered arrays of display
+# lines: the single source of truth for every surface that renders an address
+# (storefront order pages, admin order page, ops confirmation email HTML +
+# text, and the PDF), mirroring OrderSummary's role for the money lines. Each
+# surface only supplies medium-specific markup and iterates these lines; the
+# name always comes first so a surface may emphasise it.
+#
+# billing_lines returns:
+#   - [] when the order has no billing address (orders predating billing
+#     collection, or a session Stripe returned none for) - render nothing.
+#   - [SAME_AS_SHIPPING_NOTE] when billing matches the delivery address -
+#     render the single note instead of repeating the block.
+#   - the full address lines otherwise.
+class OrderAddress
+  SAME_AS_SHIPPING_NOTE = "Same as delivery address"
+
+  def self.shipping_lines(order)
+    lines(
+      name: order.shipping_name,
+      line1: order.shipping_address_line1,
+      line2: order.shipping_address_line2,
+      city: order.shipping_city,
+      postal_code: order.shipping_postal_code,
+      country: order.shipping_country
+    )
+  end
+
+  def self.billing_lines(order)
+    return [] unless order.billing_address?
+    return [ SAME_AS_SHIPPING_NOTE ] if order.billing_same_as_shipping?
+
+    lines(
+      name: order.billing_name,
+      line1: order.billing_address_line1,
+      line2: order.billing_address_line2,
+      city: order.billing_city,
+      postal_code: order.billing_postal_code,
+      country: order.billing_country
+    )
+  end
+
+  def self.lines(name:, line1:, line2:, city:, postal_code:, country:)
+    [
+      name,
+      line1,
+      line2.presence,
+      [ city, postal_code ].select(&:present?).join(", ").presence,
+      country
+    ].compact
+  end
+  private_class_method :lines
+end

--- a/app/services/order_address.rb
+++ b/app/services/order_address.rb
@@ -3,15 +3,19 @@
 # The order's shipping and billing addresses as ordered arrays of display
 # lines: the single source of truth for every surface that renders an address
 # (storefront order pages, admin order page, ops confirmation email HTML +
-# text, and the PDF), mirroring OrderSummary's role for the money lines. Each
-# surface only supplies medium-specific markup and iterates these lines; the
-# name always comes first so a surface may emphasise it.
+# text, and the PDF), mirroring OrderSummary's role for the money lines.
+#
+# Each line is { kind:, text: }. kind is the one contract surfaces style
+# against - :name may be emphasised, :address and :note render plain - so no
+# surface infers "the first line is the name" from position: an order whose
+# billing name Stripe never returned simply has no :name line, and the
+# same-as-delivery note is never mistaken for a name.
 #
 # billing_lines returns:
 #   - [] when the order has no billing address (orders predating billing
 #     collection, or a session Stripe returned none for) - render nothing.
-#   - [SAME_AS_SHIPPING_NOTE] when billing matches the delivery address -
-#     render the single note instead of repeating the block.
+#   - the :note line when billing matches the delivery address - render it
+#     instead of repeating the block.
 #   - the full address lines otherwise.
 class OrderAddress
   SAME_AS_SHIPPING_NOTE = "Same as delivery address"
@@ -29,7 +33,7 @@ class OrderAddress
 
   def self.billing_lines(order)
     return [] unless order.billing_address?
-    return [ SAME_AS_SHIPPING_NOTE ] if order.billing_same_as_shipping?
+    return [ { kind: :note, text: SAME_AS_SHIPPING_NOTE } ] if order.billing_same_as_shipping?
 
     lines(
       name: order.billing_name,
@@ -42,13 +46,15 @@ class OrderAddress
   end
 
   def self.lines(name:, line1:, line2:, city:, postal_code:, country:)
-    [
-      name,
+    texts = [
       line1,
       line2.presence,
       [ city, postal_code ].select(&:present?).join(", ").presence,
       country
     ].compact
+
+    address_lines = texts.map { |text| { kind: :address, text: text } }
+    name.present? ? [ { kind: :name, text: name }, *address_lines ] : address_lines
   end
   private_class_method :lines
 end

--- a/app/services/order_pdf_generator.rb
+++ b/app/services/order_pdf_generator.rb
@@ -137,7 +137,12 @@ class OrderPdfGenerator
 
   def add_details_section(pdf)
     column_width = (pdf.bounds.width - 30) / 2
-    section_height = 100
+    # The right column also carries a billing block when one was collected;
+    # both boxes share the measured height so the columns stay aligned. The
+    # height is measured from the actual lines (as add_price_summary sizes from
+    # its row count) because a bounding_box too small for its content makes
+    # Prawn treat the box bottom as a page edge and break onto a second page.
+    section_height = address_section_height(pdf, column_width)
 
     # Left column: Order details
     pdf.bounding_box([ 0, pdf.cursor ], width: column_width, height: section_height) do
@@ -150,22 +155,45 @@ class OrderPdfGenerator
       add_detail_row(pdf, "Email", @order.email) if @order.email.present?
     end
 
-    # Right column: Shipping address
+    # Right column: Shipping (and, when collected, billing) address
     pdf.bounding_box([ column_width + 30, pdf.cursor + section_height ], width: column_width, height: section_height) do
-      add_section_header(pdf, "Shipping Address")
-      pdf.move_down 8
+      add_address_block(pdf, "Shipping Address", OrderAddress.shipping_lines(@order))
 
-      pdf.fill_color TEXT_DARK
-      pdf.text @order.shipping_name.to_s, size: 10, style: :bold
-      pdf.move_down 3
-      pdf.fill_color TEXT_GRAY
-      pdf.text @order.shipping_address_line1.to_s, size: 10
-      pdf.text @order.shipping_address_line2.to_s, size: 10 if @order.shipping_address_line2.present?
-      pdf.text "#{@order.shipping_city}, #{@order.shipping_postal_code}".strip, size: 10
-      pdf.text @order.shipping_country.to_s, size: 10
+      if @order.billing_address?
+        pdf.move_down 10
+        add_address_block(pdf, "Billing Address", OrderAddress.billing_lines(@order))
+      end
     end
 
     pdf.fill_color TEXT_DARK
+  end
+
+  def add_address_block(pdf, title, lines)
+    add_section_header(pdf, title)
+    pdf.move_down 8
+
+    lines.each_with_index do |line, index|
+      pdf.fill_color(index.zero? ? TEXT_DARK : TEXT_GRAY)
+      pdf.text line, size: 10
+      pdf.move_down 3 if index.zero?
+    end
+  end
+
+  # Measured height of the right column's content (add_address_block must stay
+  # in step), with the left column's fixed rows as the floor. height_of wraps
+  # against the column width, so long address lines that break count in full.
+  def address_section_height(pdf, column_width)
+    height = address_block_height(pdf, "Shipping Address", OrderAddress.shipping_lines(@order), column_width)
+    if @order.billing_address?
+      height += 10 + address_block_height(pdf, "Billing Address", OrderAddress.billing_lines(@order), column_width)
+    end
+
+    [ height + 4, 100 ].max
+  end
+
+  def address_block_height(pdf, title, lines, column_width)
+    pdf.height_of(title, size: 11, width: column_width) + 8 +
+      lines.sum { |line| pdf.height_of(line, size: 10, width: column_width) } + 3
   end
 
   def add_section_header(pdf, title)

--- a/app/services/order_pdf_generator.rb
+++ b/app/services/order_pdf_generator.rb
@@ -9,6 +9,16 @@ class OrderPdfGenerator
   TEXT_DARK = "1F2937".freeze          # Near black for headings
   TEXT_GRAY = "6B7280".freeze          # Gray for secondary text
   LIGHT_GRAY = "F3F4F6".freeze         # Table alternating row
+
+  # Address block typography, shared by add_address_block (render) and
+  # address_block_height (measure) so the measured bounding box can never
+  # drift from what is drawn - an undersized box makes Prawn treat its bottom
+  # as a page edge and break the whole layout onto a second page.
+  SECTION_HEADER_SIZE = 11
+  ADDRESS_LINE_SIZE = 10
+  ADDRESS_TITLE_GAP = 8
+  ADDRESS_NAME_GAP = 3
+  ADDRESS_BLOCK_GAP = 10
   BORDER_GRAY = "E5E7EB".freeze        # Subtle borders
 
   COMPANY_NAME = "Afida".freeze
@@ -137,12 +147,13 @@ class OrderPdfGenerator
 
   def add_details_section(pdf)
     column_width = (pdf.bounds.width - 30) / 2
+    shipping_lines = OrderAddress.shipping_lines(@order)
+    billing_lines = OrderAddress.billing_lines(@order)
     # The right column also carries a billing block when one was collected;
     # both boxes share the measured height so the columns stay aligned. The
-    # height is measured from the actual lines (as add_price_summary sizes from
-    # its row count) because a bounding_box too small for its content makes
-    # Prawn treat the box bottom as a page edge and break onto a second page.
-    section_height = address_section_height(pdf, column_width)
+    # height is measured from the same lines that render (as add_price_summary
+    # sizes from its row count).
+    section_height = address_section_height(pdf, column_width, shipping_lines, billing_lines)
 
     # Left column: Order details
     pdf.bounding_box([ 0, pdf.cursor ], width: column_width, height: section_height) do
@@ -157,48 +168,58 @@ class OrderPdfGenerator
 
     # Right column: Shipping (and, when collected, billing) address
     pdf.bounding_box([ column_width + 30, pdf.cursor + section_height ], width: column_width, height: section_height) do
-      add_address_block(pdf, "Shipping Address", OrderAddress.shipping_lines(@order))
+      add_address_block(pdf, "Shipping Address", shipping_lines)
 
-      if @order.billing_address?
-        pdf.move_down 10
-        add_address_block(pdf, "Billing Address", OrderAddress.billing_lines(@order))
+      if billing_lines.any?
+        pdf.move_down ADDRESS_BLOCK_GAP
+        add_address_block(pdf, "Billing Address", billing_lines)
       end
     end
 
     pdf.fill_color TEXT_DARK
   end
 
+  # Only :name lines get the dark emphasis and trailing gap; :address and
+  # :note lines (incl. the same-as-delivery note) render plain gray, matching
+  # the other surfaces.
   def add_address_block(pdf, title, lines)
     add_section_header(pdf, title)
-    pdf.move_down 8
+    pdf.move_down ADDRESS_TITLE_GAP
 
-    lines.each_with_index do |line, index|
-      pdf.fill_color(index.zero? ? TEXT_DARK : TEXT_GRAY)
-      pdf.text line, size: 10
-      pdf.move_down 3 if index.zero?
+    lines.each do |line|
+      name = line[:kind] == :name
+      pdf.fill_color(name ? TEXT_DARK : TEXT_GRAY)
+      pdf.text line[:text], size: ADDRESS_LINE_SIZE
+      pdf.move_down ADDRESS_NAME_GAP if name
     end
   end
 
-  # Measured height of the right column's content (add_address_block must stay
-  # in step), with the left column's fixed rows as the floor. height_of wraps
-  # against the column width, so long address lines that break count in full.
-  def address_section_height(pdf, column_width)
-    height = address_block_height(pdf, "Shipping Address", OrderAddress.shipping_lines(@order), column_width)
-    if @order.billing_address?
-      height += 10 + address_block_height(pdf, "Billing Address", OrderAddress.billing_lines(@order), column_width)
+  # Measured height of the right column's content, with the left column's
+  # fixed rows as the floor. height_of wraps against the column width, so long
+  # address lines that break count in full. The per-block ADDRESS_NAME_GAP is
+  # an allowance: blocks without a :name line render without the gap, so the
+  # box can only be over-sized, never under.
+  def address_section_height(pdf, column_width, shipping_lines, billing_lines)
+    height = address_block_height(pdf, "Shipping Address", shipping_lines, column_width)
+    if billing_lines.any?
+      height += ADDRESS_BLOCK_GAP + address_block_height(pdf, "Billing Address", billing_lines, column_width)
     end
 
     [ height + 4, 100 ].max
   end
 
   def address_block_height(pdf, title, lines, column_width)
-    pdf.height_of(title, size: 11, width: column_width) + 8 +
-      lines.sum { |line| pdf.height_of(line, size: 10, width: column_width) } + 3
+    # Titles render bold (add_section_header); measure them bold too, or a
+    # wrapping title would be undercounted.
+    pdf.height_of(title, size: SECTION_HEADER_SIZE, style: :bold, width: column_width) +
+      ADDRESS_TITLE_GAP +
+      lines.sum { |line| pdf.height_of(line[:text], size: ADDRESS_LINE_SIZE, width: column_width) } +
+      ADDRESS_NAME_GAP
   end
 
   def add_section_header(pdf, title)
     pdf.fill_color PRIMARY_DARK
-    pdf.text title, size: 11, style: :bold
+    pdf.text title, size: SECTION_HEADER_SIZE, style: :bold
     pdf.fill_color TEXT_DARK
   end
 

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -134,18 +134,18 @@
           <h2 class="card-title text-lg mb-4">Shipping Address</h2>
 
           <div class="text-sm">
-            <% shipping_address_lines(@order).each_with_index do |line, index| %>
-              <p class="<%= index.zero? ? "font-medium" : "text-base-content/80" %>"><%= line %></p>
+            <% shipping_address_lines(@order).each do |line| %>
+              <p class="<%= line[:kind] == :name ? "font-medium" : "text-base-content/80" %>"><%= line[:text] %></p>
             <% end %>
           </div>
 
-          <% if show_billing_address?(@order) %>
+          <% if @order.billing_address? %>
             <div class="divider my-2"></div>
 
             <p class="text-sm text-base-content/60 mb-1">Billing Address</p>
             <div class="text-sm">
               <% billing_address_lines(@order).each do |line| %>
-                <p class="text-base-content/80"><%= line %></p>
+                <p class="text-base-content/80"><%= line[:text] %></p>
               <% end %>
             </div>
           <% end %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -134,14 +134,21 @@
           <h2 class="card-title text-lg mb-4">Shipping Address</h2>
 
           <div class="text-sm">
-            <p class="font-medium"><%= @order.shipping_name %></p>
-            <p class="text-base-content/80"><%= @order.shipping_address_line1 %></p>
-            <% if @order.shipping_address_line2.present? %>
-              <p class="text-base-content/80"><%= @order.shipping_address_line2 %></p>
+            <% shipping_address_lines(@order).each_with_index do |line, index| %>
+              <p class="<%= index.zero? ? "font-medium" : "text-base-content/80" %>"><%= line %></p>
             <% end %>
-            <p class="text-base-content/80"><%= @order.shipping_city %>, <%= @order.shipping_postal_code %></p>
-            <p class="text-base-content/80"><%= @order.shipping_country %></p>
           </div>
+
+          <% if show_billing_address?(@order) %>
+            <div class="divider my-2"></div>
+
+            <p class="text-sm text-base-content/60 mb-1">Billing Address</p>
+            <div class="text-sm">
+              <% billing_address_lines(@order).each do |line| %>
+                <p class="text-base-content/80"><%= line %></p>
+              <% end %>
+            </div>
+          <% end %>
 
           <div class="divider my-2"></div>
 

--- a/app/views/checkouts/show.html.erb
+++ b/app/views/checkouts/show.html.erb
@@ -77,6 +77,18 @@
         <div data-onsite-checkout-target="payment"></div>
       </section>
 
+      <%# The session is created with billing_address_collection "required", and
+          in custom mode the Payment Element does NOT collect billing: this
+          Billing Address Element must be mounted or canConfirm never turns
+          true and the Pay button stays dead. Stripe renders its own "same as
+          shipping" checkbox here (elementsOptions syncAddressCheckbox defaults
+          to the billing element) because both address elements share the one
+          Elements instance. %>
+      <section>
+        <h2 class="text-lg mb-2">Billing address</h2>
+        <div data-onsite-checkout-target="billingAddress"></div>
+      </section>
+
       <p class="text-sm text-error hidden" data-onsite-checkout-target="error"></p>
 
       <button type="button" class="btn btn-primary w-full" disabled

--- a/app/views/order_mailer/ops_confirmation_email.html.erb
+++ b/app/views/order_mailer/ops_confirmation_email.html.erb
@@ -64,16 +64,20 @@
 
   <tr>
     <td style="padding: 20px 30px;">
-      <h2 style="font-size: 18px; font-weight: 600; color: #111827; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px;">Ship to</h2>
+      <h2 style="font-size: 18px; font-weight: 500; color: #111827; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px;">Ship to</h2>
       <p style="font-size: 15px; color: #374151; margin: 16px 0 0 0; line-height: 1.6;">
-        <%= @order.shipping_name %><br>
-        <%= @order.shipping_address_line1 %><br>
-        <% if @order.shipping_address_line2.present? %>
-          <%= @order.shipping_address_line2 %><br>
+        <% shipping_address_lines(@order).each do |line| %>
+          <%= line %><br>
         <% end %>
-        <%= @order.shipping_city %>, <%= @order.shipping_postal_code %><br>
-        <%= @order.shipping_country %>
       </p>
+      <% if show_billing_address?(@order) %>
+        <h2 style="font-size: 18px; font-weight: 500; color: #111827; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px; margin-top: 24px;">Bill to</h2>
+        <p style="font-size: 15px; color: #374151; margin: 16px 0 0 0; line-height: 1.6;">
+          <% billing_address_lines(@order).each do |line| %>
+            <%= line %><br>
+          <% end %>
+        </p>
+      <% end %>
       <p style="font-size: 15px; color: #374151; margin: 12px 0 0 0;">
         Email: <a href="mailto:<%= @order.email %>" style="color: #111827;"><%= @order.email %></a>
       </p>

--- a/app/views/order_mailer/ops_confirmation_email.html.erb
+++ b/app/views/order_mailer/ops_confirmation_email.html.erb
@@ -67,14 +67,14 @@
       <h2 style="font-size: 18px; font-weight: 500; color: #111827; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px;">Ship to</h2>
       <p style="font-size: 15px; color: #374151; margin: 16px 0 0 0; line-height: 1.6;">
         <% shipping_address_lines(@order).each do |line| %>
-          <%= line %><br>
+          <%= line[:text] %><br>
         <% end %>
       </p>
-      <% if show_billing_address?(@order) %>
+      <% if @order.billing_address? %>
         <h2 style="font-size: 18px; font-weight: 500; color: #111827; border-bottom: 2px solid #e5e7eb; padding-bottom: 10px; margin-top: 24px;">Bill to</h2>
         <p style="font-size: 15px; color: #374151; margin: 16px 0 0 0; line-height: 1.6;">
           <% billing_address_lines(@order).each do |line| %>
-            <%= line %><br>
+            <%= line[:text] %><br>
           <% end %>
         </p>
       <% end %>

--- a/app/views/order_mailer/ops_confirmation_email.text.erb
+++ b/app/views/order_mailer/ops_confirmation_email.text.erb
@@ -18,10 +18,16 @@ ITEMS TO PICK
 
 SHIP TO
 -------
-<%= @order.shipping_name %>
-<%= @order.shipping_address_line1 %>
-<% if @order.shipping_address_line2.present? %><%= @order.shipping_address_line2 %>
-<% end %><%= @order.shipping_city %>, <%= @order.shipping_postal_code %>
-<%= @order.shipping_country %>
+<% shipping_address_lines(@order).each do |line| -%>
+<%= line %>
+<% end -%>
+<% if show_billing_address?(@order) -%>
+
+BILL TO
+-------
+<% billing_address_lines(@order).each do |line| -%>
+<%= line %>
+<% end -%>
+<% end -%>
 
 Email: <%= @order.email %>

--- a/app/views/order_mailer/ops_confirmation_email.text.erb
+++ b/app/views/order_mailer/ops_confirmation_email.text.erb
@@ -19,14 +19,14 @@ ITEMS TO PICK
 SHIP TO
 -------
 <% shipping_address_lines(@order).each do |line| -%>
-<%= line %>
+<%= line[:text] %>
 <% end -%>
-<% if show_billing_address?(@order) -%>
+<% if @order.billing_address? -%>
 
 BILL TO
 -------
 <% billing_address_lines(@order).each do |line| -%>
-<%= line %>
+<%= line[:text] %>
 <% end -%>
 <% end -%>
 

--- a/app/views/orders/_address.html.erb
+++ b/app/views/orders/_address.html.erb
@@ -1,0 +1,29 @@
+<%# The storefront address card body, shared by orders/show and
+    orders/confirmation so the two stay identical (mirroring orders/_summary
+    for the money lines). Lines come from OrderAddress via OrdersHelper: the
+    billing block renders only when a billing address was collected, and shows
+    a "Same as delivery address" note instead of duplicating the block. %>
+<div class="p-6">
+  <div class="text-gray-900">
+    <% shipping_address_lines(order).each_with_index do |line, index| %>
+      <p class="<%= "font-medium" if index.zero? %>"><%= line %></p>
+    <% end %>
+  </div>
+
+  <% if show_billing_address?(order) %>
+    <div class="mt-4 pt-4 border-t">
+      <p class="text-sm text-gray-600 mb-1">Billing Address</p>
+      <div class="text-gray-900">
+        <% billing_address_lines(order).each do |line| %>
+          <p><%= line %></p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="mt-4 pt-4 border-t">
+    <p class="text-sm text-gray-600">
+      Email: <%= order.email %>
+    </p>
+  </div>
+</div>

--- a/app/views/orders/_address.html.erb
+++ b/app/views/orders/_address.html.erb
@@ -1,21 +1,22 @@
 <%# The storefront address card body, shared by orders/show and
     orders/confirmation so the two stay identical (mirroring orders/_summary
-    for the money lines). Lines come from OrderAddress via OrdersHelper: the
-    billing block renders only when a billing address was collected, and shows
-    a "Same as delivery address" note instead of duplicating the block. %>
+    for the money lines). Lines come from OrderAddress via OrdersHelper as
+    {kind:, text:} - only :name lines are emphasised. The billing block
+    renders only when a billing address was collected, and shows a "Same as
+    delivery address" note instead of duplicating the block. %>
 <div class="p-6">
   <div class="text-gray-900">
-    <% shipping_address_lines(order).each_with_index do |line, index| %>
-      <p class="<%= "font-medium" if index.zero? %>"><%= line %></p>
+    <% shipping_address_lines(order).each do |line| %>
+      <p class="<%= "font-medium" if line[:kind] == :name %>"><%= line[:text] %></p>
     <% end %>
   </div>
 
-  <% if show_billing_address?(order) %>
+  <% if order.billing_address? %>
     <div class="mt-4 pt-4 border-t">
       <p class="text-sm text-gray-600 mb-1">Billing Address</p>
       <div class="text-gray-900">
         <% billing_address_lines(order).each do |line| %>
-          <p><%= line %></p>
+          <p><%= line[:text] %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/orders/confirmation.html.erb
+++ b/app/views/orders/confirmation.html.erb
@@ -118,23 +118,7 @@
           <h2 class="text-xl text-gray-900">Shipping Address</h2>
         </div>
 
-        <div class="p-6">
-          <div class="text-gray-900">
-            <p><%= @order.shipping_name %></p>
-            <p><%= @order.shipping_address_line1 %></p>
-            <% if @order.shipping_address_line2.present? %>
-              <p><%= @order.shipping_address_line2 %></p>
-            <% end %>
-            <p><%= @order.shipping_city %>, <%= @order.shipping_postal_code %></p>
-            <p><%= @order.shipping_country %></p>
-          </div>
-
-          <div class="mt-4 pt-4 border-t">
-            <p class="text-sm text-gray-600">
-              Email: <%= @order.email %>
-            </p>
-          </div>
-        </div>
+        <%= render "orders/address", order: @order %>
       </div>
     </div>
 

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -95,23 +95,7 @@
           <h2 class="text-gray-900">Shipping Address</h2>
         </div>
 
-        <div class="p-6">
-          <div class="text-gray-900">
-            <p class="font-medium"><%= @order.shipping_name %></p>
-            <p><%= @order.shipping_address_line1 %></p>
-            <% if @order.shipping_address_line2.present? %>
-              <p><%= @order.shipping_address_line2 %></p>
-            <% end %>
-            <p><%= @order.shipping_city %>, <%= @order.shipping_postal_code %></p>
-            <p><%= @order.shipping_country %></p>
-          </div>
-
-          <div class="mt-4 pt-4 border-t">
-            <p class="text-sm text-gray-600">
-              <strong>Email:</strong> <%= @order.email %>
-            </p>
-          </div>
-        </div>
+        <%= render "orders/address", order: @order %>
       </div>
     </div>
 

--- a/db/migrate/20260817114044_add_billing_address_to_orders.rb
+++ b/db/migrate/20260817114044_add_billing_address_to_orders.rb
@@ -1,0 +1,18 @@
+# The customer's billing address, collected at Stripe Checkout via
+# billing_address_collection: "required" (Checkout::SessionBuilder) and read
+# from the completed session's customer_details. Nullable and NOT validated for
+# presence, unlike the shipping_* columns: orders created before this feature
+# have none, and some sessions (Link/wallet reuse, zero-total
+# no_payment_required) may legitimately return no billing address. A missing
+# billing address must never block order creation - see
+# Checkout::SessionDetails.billing_address.
+class AddBillingAddressToOrders < ActiveRecord::Migration[8.1]
+  def change
+    add_column :orders, :billing_name, :string
+    add_column :orders, :billing_address_line1, :string
+    add_column :orders, :billing_address_line2, :string
+    add_column :orders, :billing_city, :string
+    add_column :orders, :billing_postal_code, :string
+    add_column :orders, :billing_country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_202019) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_114044) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -282,6 +282,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_202019) do
   end
 
   create_table "orders", force: :cascade do |t|
+    t.string "billing_address_line1"
+    t.string "billing_address_line2"
+    t.string "billing_city"
+    t.string "billing_country"
+    t.string "billing_name"
+    t.string "billing_postal_code"
     t.string "branded_order_status"
     t.datetime "created_at", null: false
     t.decimal "discount_amount", precision: 10, scale: 2, default: "0.0", null: false

--- a/test/controllers/admin/orders_controller_test.rb
+++ b/test/controllers/admin/orders_controller_test.rb
@@ -116,6 +116,43 @@ class Admin::OrdersControllerTest < ActionDispatch::IntegrationTest
     assert_select "span", text: /Discount/, count: 0
   end
 
+  # The address block renders via OrderAddress (shared with the storefront
+  # pages, ops email and PDF): billing appears only when collected, and as a
+  # "Same as delivery address" note when it matches the delivery address.
+  test "show renders the shipping address and no billing block by default" do
+    get admin_order_path(@regular_order), headers: @headers
+
+    assert_response :success
+    assert_match @regular_order.shipping_address_line1, response.body
+    assert_no_match(/Billing Address/, response.body)
+  end
+
+  test "show renders a distinct billing address when one was collected" do
+    @regular_order.update_columns(
+      billing_name: "Accounts Payable", billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester", billing_postal_code: "M1 1AA", billing_country: "GB"
+    )
+    get admin_order_path(@regular_order), headers: @headers
+
+    assert_match "Billing Address", response.body
+    assert_match "1 Finance Row", response.body
+  end
+
+  test "show renders a same-as-delivery note when billing matches shipping" do
+    @regular_order.update_columns(
+      billing_name: @regular_order.shipping_name,
+      billing_address_line1: @regular_order.shipping_address_line1,
+      billing_address_line2: @regular_order.shipping_address_line2,
+      billing_city: @regular_order.shipping_city,
+      billing_postal_code: @regular_order.shipping_postal_code,
+      billing_country: @regular_order.shipping_country
+    )
+    get admin_order_path(@regular_order), headers: @headers
+
+    assert_match "Same as delivery address", response.body
+    assert_equal 1, response.body.scan(@regular_order.shipping_address_line1).count
+  end
+
   test "show displays effective sample SKU for sample items" do
     get admin_order_path(@sample_only_order), headers: @headers
 

--- a/test/controllers/checkouts_controller_test.rb
+++ b/test/controllers/checkouts_controller_test.rb
@@ -178,6 +178,10 @@ class CheckoutsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller='onsite-checkout']"
     assert_select "[data-onsite-checkout-target='payment']"
     assert_select "[data-onsite-checkout-target='address']"
+    # With billing_address_collection "required", custom mode must mount its
+    # own Billing Address Element or canConfirm never turns true (dead Pay
+    # button); the Payment Element does not collect billing in this mode.
+    assert_select "[data-onsite-checkout-target='billingAddress']"
     assert_select "[data-onsite-checkout-publishable-key-value]" do |elements|
       assert elements.first["data-onsite-checkout-publishable-key-value"].present?,
         "publishable key must reach the page"

--- a/test/controllers/orders_controller_test.rb
+++ b/test/controllers/orders_controller_test.rb
@@ -86,6 +86,55 @@ class OrdersControllerTest < ActionDispatch::IntegrationTest
   end
 
   # T013: User viewing another user's order (denied)
+  # The address block renders via OrderAddress, shared with the admin page,
+  # ops email and PDF: shipping always, billing only when collected, and a
+  # "Same as delivery address" note instead of a duplicate block.
+  test "show renders the shipping address and no billing block by default" do
+    sign_in @user_one
+    get order_url(@order_one)
+    assert_response :success
+    assert_match @order_one.shipping_address_line1, response.body
+    assert_no_match(/Billing Address/, response.body)
+  end
+
+  test "show renders a distinct billing address when one was collected" do
+    @order_one.update_columns(
+      billing_name: "Accounts Payable", billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester", billing_postal_code: "M1 1AA", billing_country: "GB"
+    )
+    sign_in @user_one
+    get order_url(@order_one)
+    assert_match "Billing Address", response.body
+    assert_match "1 Finance Row", response.body
+  end
+
+  test "show renders a same-as-delivery note when billing matches shipping" do
+    @order_one.update_columns(
+      billing_name: @order_one.shipping_name,
+      billing_address_line1: @order_one.shipping_address_line1,
+      billing_address_line2: @order_one.shipping_address_line2,
+      billing_city: @order_one.shipping_city,
+      billing_postal_code: @order_one.shipping_postal_code,
+      billing_country: @order_one.shipping_country
+    )
+    sign_in @user_one
+    get order_url(@order_one)
+    assert_match "Billing Address", response.body
+    assert_match "Same as delivery address", response.body
+    assert_equal 1, response.body.scan(@order_one.shipping_address_line1).count
+  end
+
+  test "confirmation renders a billing address when one was collected" do
+    @order_one.update_columns(
+      billing_name: "Accounts Payable", billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester", billing_postal_code: "M1 1AA", billing_country: "GB"
+    )
+    sign_in @user_one
+    get confirmation_order_url(@order_one)
+    assert_match "Billing Address", response.body
+    assert_match "1 Finance Row", response.body
+  end
+
   test "show redirects when accessing another user's order" do
     sign_in @user_one
     get order_url(@order_two)  # order_two belongs to user_two

--- a/test/controllers/webhooks/stripe_controller_test.rb
+++ b/test/controllers/webhooks/stripe_controller_test.rb
@@ -283,6 +283,64 @@ class Webhooks::StripeControllerTest < ActionDispatch::IntegrationTest
     assert_enqueued_with(job: TelegramOrderNotificationJob, args: [ order.id ])
   end
 
+  test "creates order with the collected billing address" do
+    cart = Cart.create!
+    product = products(:one)
+    cart.cart_items.create!(product: product, quantity: 1, price: product.price)
+
+    session = build_stripe_session(
+      id: "sess_with_billing",
+      payment_status: "paid",
+      metadata: { cart_id: cart.id.to_s },
+      amount_total: 3500,
+      amount_tax: 500,
+      billing_name: "Accounts Payable",
+      billing_address: { line1: "1 Finance Row", city: "Manchester", postal_code: "M1 1AA", country: "GB" }
+    )
+
+    event = build_stripe_webhook_event(type: "checkout.session.completed", data_object: session)
+    stub_stripe_webhook_construct_event(event)
+    Stripe::Checkout::Session.stubs(:retrieve).returns(session)
+
+    assert_difference "Order.count", 1 do
+      post webhooks_stripe_url, params: "{}", headers: { "HTTP_STRIPE_SIGNATURE" => "valid_sig" }
+    end
+
+    order = Order.find_by(stripe_session_id: "sess_with_billing")
+    assert_equal "Accounts Payable", order.billing_name
+    assert_equal "1 Finance Row", order.billing_address_line1
+    assert_equal "Manchester", order.billing_city
+    assert_equal "M1 1AA", order.billing_postal_code
+    assert_equal "GB", order.billing_country
+  end
+
+  test "creates order without a billing address when the session carries none" do
+    cart = Cart.create!
+    product = products(:one)
+    cart.cart_items.create!(product: product, quantity: 1, price: product.price)
+
+    session = build_stripe_session(
+      id: "sess_without_billing",
+      payment_status: "paid",
+      metadata: { cart_id: cart.id.to_s },
+      amount_total: 3500,
+      amount_tax: 500,
+      billing_address: nil
+    )
+
+    event = build_stripe_webhook_event(type: "checkout.session.completed", data_object: session)
+    stub_stripe_webhook_construct_event(event)
+    Stripe::Checkout::Session.stubs(:retrieve).returns(session)
+
+    assert_difference "Order.count", 1 do
+      post webhooks_stripe_url, params: "{}", headers: { "HTTP_STRIPE_SIGNATURE" => "valid_sig" }
+    end
+
+    order = Order.find_by(stripe_session_id: "sess_without_billing")
+    assert_nil order.billing_name
+    assert_not order.billing_address?
+  end
+
   test "rolls back the order when an order item fails, leaving no item-less paid order" do
     # The order and its items must be created atomically: a mid-loop OrderItem
     # failure must not leave a committed paid order with missing items.

--- a/test/mailers/order_mailer_test.rb
+++ b/test/mailers/order_mailer_test.rb
@@ -226,6 +226,52 @@ class OrderMailerTest < ActionMailer::TestCase
     assert_match @order.email, body
   end
 
+  # The address blocks render via OrderAddress (shared with the order pages and
+  # PDF): "Bill to" appears only when a billing address was collected, and as a
+  # "Same as delivery address" note when it matches shipping.
+  test "ops_confirmation_email omits the billing block when none was collected" do
+    email = OrderMailer.with(order: @order).ops_confirmation_email
+
+    content_part = email.parts.find { |p| p.content_type.include?("multipart/alternative") } || email
+    %w[text/html text/plain].each do |type|
+      part = content_part.parts.find { |p| p.content_type.include?(type) }
+      assert_no_match(/Bill to/i, part.body.to_s, "#{type} part should have no billing block")
+    end
+  end
+
+  test "ops_confirmation_email includes a distinct billing address in both parts" do
+    @order.update_columns(
+      billing_name: "Accounts Payable", billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester", billing_postal_code: "M1 1AA", billing_country: "GB"
+    )
+    email = OrderMailer.with(order: @order).ops_confirmation_email
+
+    content_part = email.parts.find { |p| p.content_type.include?("multipart/alternative") } || email
+    %w[text/html text/plain].each do |type|
+      part = content_part.parts.find { |p| p.content_type.include?(type) }
+      assert_match(/Bill to/i, part.body.to_s, "#{type} part missing billing header")
+      assert_match "1 Finance Row", part.body.to_s, "#{type} part missing billing address"
+    end
+  end
+
+  test "ops_confirmation_email notes when billing matches the delivery address" do
+    @order.update_columns(
+      billing_name: @order.shipping_name,
+      billing_address_line1: @order.shipping_address_line1,
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+    email = OrderMailer.with(order: @order).ops_confirmation_email
+
+    content_part = email.parts.find { |p| p.content_type.include?("multipart/alternative") } || email
+    %w[text/html text/plain].each do |type|
+      part = content_part.parts.find { |p| p.content_type.include?(type) }
+      assert_match "Same as delivery address", part.body.to_s, "#{type} part missing same-as note"
+    end
+  end
+
   test "ops_confirmation_email links to the admin order page" do
     email = OrderMailer.with(order: @order).ops_confirmation_email
 

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -130,6 +130,65 @@ class OrderTest < ActiveSupport::TestCase
     assert_not_includes address, "nil"
   end
 
+  test "billing address fields are optional" do
+    order = Order.new(@valid_attributes)
+    assert order.valid?
+    assert_nil order.billing_name
+  end
+
+  test "billing_address? is false when no billing was collected" do
+    assert_not @order.billing_address?
+  end
+
+  test "billing_address? is true when billing was collected" do
+    @order.billing_address_line1 = "5 Analytical Way"
+    assert @order.billing_address?
+  end
+
+  test "billing_same_as_shipping? is true when all fields match" do
+    @order.assign_attributes(
+      billing_name: @order.shipping_name,
+      billing_address_line1: @order.shipping_address_line1,
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+    assert @order.billing_same_as_shipping?
+  end
+
+  # Stripe populates billing_name (customer_details.name) independently of the
+  # shipping recipient (cardholder vs recipient, abbreviated vs full name), so
+  # comparing names would make the same-address case look different for most
+  # real orders. Only the address decides.
+  test "billing_same_as_shipping? is true when only the name differs" do
+    @order.assign_attributes(
+      billing_name: "Accounts Payable",
+      billing_address_line1: @order.shipping_address_line1,
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+    assert @order.billing_same_as_shipping?
+  end
+
+  test "billing_same_as_shipping? is false when the address differs" do
+    @order.assign_attributes(
+      billing_name: @order.shipping_name,
+      billing_address_line1: "1 Finance Row",
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+    assert_not @order.billing_same_as_shipping?
+  end
+
+  test "billing_same_as_shipping? is false when there is no billing address" do
+    assert_not @order.billing_same_as_shipping?
+  end
+
   test "display_number formats order_number with hash" do
     assert_equal "##{@order.order_number}", @order.display_number
   end

--- a/test/services/checkout/order_creator_test.rb
+++ b/test/services/checkout/order_creator_test.rb
@@ -56,6 +56,43 @@ class Checkout::OrderCreatorTest < ActiveSupport::TestCase
     assert_equal 24.0, order.total_amount.to_f
   end
 
+  test "records the billing address when the session carries one" do
+    stripe_session = build_stripe_session(
+      customer_email: "buyer@example.com",
+      amount_subtotal: 2000,
+      amount_tax: 400,
+      amount_total: 2400,
+      billing_name: "Accounts Payable",
+      billing_address: { line1: "1 Finance Row", city: "Manchester", postal_code: "M1 1AA", country: "GB" },
+      line_items_data: [ stripe_product_line_item(amount_subtotal: 2000) ]
+    )
+
+    order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+
+    assert_equal "Accounts Payable", order.billing_name
+    assert_equal "1 Finance Row", order.billing_address_line1
+    assert_nil order.billing_address_line2
+    assert_equal "Manchester", order.billing_city
+    assert_equal "M1 1AA", order.billing_postal_code
+    assert_equal "GB", order.billing_country
+  end
+
+  test "still creates the order when the session carries no billing address" do
+    stripe_session = build_stripe_session(
+      customer_email: "buyer@example.com",
+      amount_subtotal: 2000,
+      amount_tax: 400,
+      amount_total: 2400,
+      billing_address: nil,
+      line_items_data: [ stripe_product_line_item(amount_subtotal: 2000) ]
+    )
+
+    order = Checkout::OrderCreator.new(stripe_session: stripe_session, cart: @cart).create
+
+    assert_nil order.billing_name
+    assert_not order.billing_address?
+  end
+
   test "stamps the delivery zone from the address Stripe collected" do
     # The zone is recorded on the order so what the customer was charged and
     # promised survives any later change to the zone table or rate card.

--- a/test/services/checkout/session_builder_test.rb
+++ b/test/services/checkout/session_builder_test.rb
@@ -418,6 +418,34 @@ class Checkout::SessionBuilderTest < ActiveSupport::TestCase
     assert captured_params[:shipping_address_collection]
   end
 
+  test "collects a required billing address in hosted mode" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_session
+
+    assert_equal "required", captured_params[:billing_address_collection]
+  end
+
+  test "collects a required billing address in custom mode" do
+    @cart.cart_items.create!(product: products(:one), quantity: 1, price: 10.00)
+
+    captured_params = nil
+    Stripe::Checkout::Session.stubs(:create).with do |params|
+      captured_params = params
+      true
+    end.returns(build_stripe_session)
+
+    build_custom_session
+
+    assert_equal "required", captured_params[:billing_address_collection]
+  end
+
   test "does not expose intermediate checkout state readers" do
     builder = build_session_builder(discount_code: "WELCOME5")
 

--- a/test/services/checkout/session_details_test.rb
+++ b/test/services/checkout/session_details_test.rb
@@ -37,6 +37,48 @@ class Checkout::SessionDetailsTest < ActiveSupport::TestCase
     assert_equal({}, Checkout::SessionDetails.shipping_address(session))
   end
 
+  # --- billing_address ---
+
+  test "billing_address maps customer_details to the order fields" do
+    session = build_stripe_session(
+      billing_name: "Ada Lovelace Ltd",
+      billing_address: { line1: "1 Finance Row", city: "Manchester", postal_code: "M1 1AA", country: "GB" }
+    )
+
+    billing = Checkout::SessionDetails.billing_address(session)
+
+    assert_equal "Ada Lovelace Ltd", billing[:name]
+    assert_equal "1 Finance Row", billing[:line1]
+    assert_nil billing[:line2]
+    assert_equal "Manchester", billing[:city]
+    assert_equal "M1 1AA", billing[:postal_code]
+    assert_equal "GB", billing[:country]
+  end
+
+  test "billing_address defaults to the shipping address like Stripe does" do
+    session = build_stripe_session(
+      shipping_name: "Ada Lovelace",
+      shipping_address: { line1: "5 Analytical Way", line2: "Engine House", city: "London", postal_code: "EC1A 1AA", country: "GB" }
+    )
+
+    billing = Checkout::SessionDetails.billing_address(session)
+
+    assert_equal "5 Analytical Way", billing[:line1]
+    assert_equal "London", billing[:city]
+  end
+
+  test "billing_address returns an empty hash when customer_details carries no address" do
+    session = build_stripe_session(billing_address: nil)
+
+    assert_equal({}, Checkout::SessionDetails.billing_address(session))
+  end
+
+  test "billing_address returns an empty hash when the session has no customer_details" do
+    session = stub(to_hash: { collected_information: {} })
+
+    assert_equal({}, Checkout::SessionDetails.billing_address(session))
+  end
+
   # --- promotion_code ---
 
   test "promotion_code returns the code from the discount breakdown" do

--- a/test/services/checkout/session_details_test.rb
+++ b/test/services/checkout/session_details_test.rb
@@ -79,6 +79,42 @@ class Checkout::SessionDetailsTest < ActiveSupport::TestCase
     assert_equal({}, Checkout::SessionDetails.billing_address(session))
   end
 
+  # --- order_address_attributes ---
+
+  test "order_address_attributes maps both addresses to order columns in one pass" do
+    session = build_stripe_session(
+      shipping_name: "Ada Lovelace",
+      shipping_address: { line1: "5 Analytical Way", line2: "Engine House", city: "London", postal_code: "EC1A 1AA", country: "GB" },
+      billing_name: "Ada Lovelace Ltd",
+      billing_address: { line1: "1 Finance Row", city: "Manchester", postal_code: "M1 1AA", country: "GB" }
+    )
+
+    attributes = Checkout::SessionDetails.order_address_attributes(session)
+
+    assert_equal "Ada Lovelace", attributes[:shipping_name]
+    assert_equal "5 Analytical Way", attributes[:shipping_address_line1]
+    assert_equal "Engine House", attributes[:shipping_address_line2]
+    assert_equal "London", attributes[:shipping_city]
+    assert_equal "EC1A 1AA", attributes[:shipping_postal_code]
+    assert_equal "GB", attributes[:shipping_country]
+    assert_equal "Ada Lovelace Ltd", attributes[:billing_name]
+    assert_equal "1 Finance Row", attributes[:billing_address_line1]
+    assert_nil attributes[:billing_address_line2]
+    assert_equal "Manchester", attributes[:billing_city]
+    assert_equal "M1 1AA", attributes[:billing_postal_code]
+    assert_equal "GB", attributes[:billing_country]
+  end
+
+  test "order_address_attributes leaves billing columns nil when the session has no billing" do
+    session = build_stripe_session(billing_address: nil)
+
+    attributes = Checkout::SessionDetails.order_address_attributes(session)
+
+    assert_equal "Test Customer", attributes[:shipping_name]
+    assert_nil attributes[:billing_name]
+    assert_nil attributes[:billing_address_line1]
+  end
+
   # --- promotion_code ---
 
   test "promotion_code returns the code from the discount breakdown" do

--- a/test/services/order_address_test.rb
+++ b/test/services/order_address_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+# OrderAddress is the single source of truth for the address lines every order
+# surface renders (storefront pages, admin page, ops email, PDF), mirroring
+# OrderSummary's role for the money lines.
+class OrderAddressTest < ActiveSupport::TestCase
+  setup do
+    @order = orders(:one)
+  end
+
+  test "shipping_lines returns the shipping address as ordered display lines" do
+    assert_equal [
+      @order.shipping_name,
+      @order.shipping_address_line1,
+      @order.shipping_address_line2,
+      "#{@order.shipping_city}, #{@order.shipping_postal_code}",
+      @order.shipping_country
+    ], OrderAddress.shipping_lines(@order)
+  end
+
+  test "shipping_lines omits a blank address_line2" do
+    @order.shipping_address_line2 = nil
+
+    lines = OrderAddress.shipping_lines(@order)
+
+    assert_not_includes lines, nil
+    assert_equal @order.shipping_address_line1, lines[1]
+    assert_equal "#{@order.shipping_city}, #{@order.shipping_postal_code}", lines[2]
+  end
+
+  test "billing_lines is empty when the order has no billing address" do
+    assert_equal [], OrderAddress.billing_lines(@order)
+  end
+
+  test "billing_lines returns the billing address when it differs from shipping" do
+    @order.assign_attributes(
+      billing_name: "Accounts Payable",
+      billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester",
+      billing_postal_code: "M1 1AA",
+      billing_country: "GB"
+    )
+
+    assert_equal [ "Accounts Payable", "1 Finance Row", "Manchester, M1 1AA", "GB" ],
+      OrderAddress.billing_lines(@order)
+  end
+
+  test "billing_lines returns a same-as-delivery note when billing matches shipping" do
+    @order.assign_attributes(
+      billing_name: @order.shipping_name,
+      billing_address_line1: @order.shipping_address_line1,
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+
+    assert_equal [ "Same as delivery address" ], OrderAddress.billing_lines(@order)
+  end
+end

--- a/test/services/order_address_test.rb
+++ b/test/services/order_address_test.rb
@@ -2,19 +2,22 @@ require "test_helper"
 
 # OrderAddress is the single source of truth for the address lines every order
 # surface renders (storefront pages, admin page, ops email, PDF), mirroring
-# OrderSummary's role for the money lines.
+# OrderSummary's role for the money lines. Each line is {kind:, text:}: kind
+# (:name/:address/:note) is the one contract surfaces style against, so "the
+# first line is the name" is never inferred from position - a nil name simply
+# has no :name line, and the same-as-delivery note is never styled as a name.
 class OrderAddressTest < ActiveSupport::TestCase
   setup do
     @order = orders(:one)
   end
 
-  test "shipping_lines returns the shipping address as ordered display lines" do
+  test "shipping_lines returns the shipping address as kinded display lines" do
     assert_equal [
-      @order.shipping_name,
-      @order.shipping_address_line1,
-      @order.shipping_address_line2,
-      "#{@order.shipping_city}, #{@order.shipping_postal_code}",
-      @order.shipping_country
+      { kind: :name, text: @order.shipping_name },
+      { kind: :address, text: @order.shipping_address_line1 },
+      { kind: :address, text: @order.shipping_address_line2 },
+      { kind: :address, text: "#{@order.shipping_city}, #{@order.shipping_postal_code}" },
+      { kind: :address, text: @order.shipping_country }
     ], OrderAddress.shipping_lines(@order)
   end
 
@@ -23,9 +26,8 @@ class OrderAddressTest < ActiveSupport::TestCase
 
     lines = OrderAddress.shipping_lines(@order)
 
-    assert_not_includes lines, nil
-    assert_equal @order.shipping_address_line1, lines[1]
-    assert_equal "#{@order.shipping_city}, #{@order.shipping_postal_code}", lines[2]
+    assert_equal @order.shipping_address_line1, lines[1][:text]
+    assert_equal "#{@order.shipping_city}, #{@order.shipping_postal_code}", lines[2][:text]
   end
 
   test "billing_lines is empty when the order has no billing address" do
@@ -41,8 +43,27 @@ class OrderAddressTest < ActiveSupport::TestCase
       billing_country: "GB"
     )
 
-    assert_equal [ "Accounts Payable", "1 Finance Row", "Manchester, M1 1AA", "GB" ],
-      OrderAddress.billing_lines(@order)
+    assert_equal [
+      { kind: :name, text: "Accounts Payable" },
+      { kind: :address, text: "1 Finance Row" },
+      { kind: :address, text: "Manchester, M1 1AA" },
+      { kind: :address, text: "GB" }
+    ], OrderAddress.billing_lines(@order)
+  end
+
+  test "billing_lines carries no name line when Stripe returned no billing name" do
+    @order.assign_attributes(
+      billing_name: nil,
+      billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester",
+      billing_postal_code: "M1 1AA",
+      billing_country: "GB"
+    )
+
+    lines = OrderAddress.billing_lines(@order)
+
+    assert_equal [], lines.select { |line| line[:kind] == :name }
+    assert_equal({ kind: :address, text: "1 Finance Row" }, lines.first)
   end
 
   test "billing_lines returns a same-as-delivery note when billing matches shipping" do
@@ -55,6 +76,7 @@ class OrderAddressTest < ActiveSupport::TestCase
       billing_country: @order.shipping_country
     )
 
-    assert_equal [ "Same as delivery address" ], OrderAddress.billing_lines(@order)
+    assert_equal [ { kind: :note, text: "Same as delivery address" } ],
+      OrderAddress.billing_lines(@order)
   end
 end

--- a/test/services/order_pdf_generator_test.rb
+++ b/test/services/order_pdf_generator_test.rb
@@ -21,6 +21,59 @@ class OrderPdfGeneratorTest < ActiveSupport::TestCase
     assert pdf_data.length > 0
   end
 
+  # The details section renders addresses via OrderAddress; existing PDF tests
+  # assert generation rather than extracted text, so these guard the billing
+  # branches (distinct address and same-as-shipping note) the same way.
+  test "generates pdf for an order with a distinct billing address" do
+    @order.update_columns(
+      billing_name: "Accounts Payable", billing_address_line1: "1 Finance Row",
+      billing_city: "Manchester", billing_postal_code: "M1 1AA", billing_country: "GB"
+    )
+
+    pdf_data = OrderPdfGenerator.new(@order).generate
+
+    assert pdf_data.length > 0
+  end
+
+  # The details section sizes its bounding box from the address line counts; a
+  # box too small for full shipping + distinct billing blocks makes Prawn treat
+  # the box bottom as a page edge and break the whole layout onto page 2.
+  test "a full shipping and distinct billing address stay on one page" do
+    @order.update_columns(
+      shipping_name: "Alexandra Featherstonehaugh",
+      shipping_address_line1: "Unit 14, Riverside Business Park",
+      shipping_address_line2: "Lower Mortlake Road",
+      shipping_city: "Richmond upon Thames",
+      shipping_postal_code: "TW9 2ND",
+      shipping_country: "GB",
+      billing_name: "Accounts Payable Department",
+      billing_address_line1: "1 Finance Row",
+      billing_address_line2: "Floor 2",
+      billing_city: "Manchester",
+      billing_postal_code: "M1 1AA",
+      billing_country: "GB"
+    )
+
+    pdf_data = OrderPdfGenerator.new(@order).generate
+
+    assert_match "/Count 1", pdf_data, "expected a single-page PDF"
+  end
+
+  test "generates pdf when billing matches the delivery address" do
+    @order.update_columns(
+      billing_name: @order.shipping_name,
+      billing_address_line1: @order.shipping_address_line1,
+      billing_address_line2: @order.shipping_address_line2,
+      billing_city: @order.shipping_city,
+      billing_postal_code: @order.shipping_postal_code,
+      billing_country: @order.shipping_country
+    )
+
+    pdf_data = OrderPdfGenerator.new(@order).generate
+
+    assert pdf_data.length > 0
+  end
+
   # T012: Test file size under 500KB
   test "pdf file size is under 500kb" do
     generator = OrderPdfGenerator.new(@order)

--- a/test/support/stripe_test_helper.rb
+++ b/test/support/stripe_test_helper.rb
@@ -63,10 +63,30 @@ module StripeTestHelper
       shipping_details: shipping_details
     )
 
+    # Billing lives on customer_details (billing_address_collection populates it;
+    # see Checkout::SessionDetails.billing_address). Stripe defaults billing to the
+    # shipping address unless the customer enters a different one, so the fixture
+    # does the same; pass billing_name:/billing_address: to diverge, or an explicit
+    # billing_address: nil to model a session where none was collected.
+    billing_name = overrides.key?(:billing_name) ? overrides[:billing_name] : customer_name
+    billing_address_hash =
+      if overrides.key?(:billing_address)
+        overrides[:billing_address] && {
+          line1: overrides[:billing_address][:line1],
+          line2: overrides[:billing_address][:line2],
+          city: overrides[:billing_address][:city],
+          postal_code: overrides[:billing_address][:postal_code],
+          country: overrides[:billing_address][:country]
+        }
+      else
+        address_hash
+      end
+    billing_address = billing_address_hash && stub(**billing_address_hash)
+
     customer_details = stub(
       email: customer_email,
-      name: customer_name,
-      address: address
+      name: billing_name,
+      address: billing_address
     )
 
     shipping_cost = legacy_shipping_amount ? stub(amount_total: legacy_shipping_amount) : nil
@@ -139,8 +159,8 @@ module StripeTestHelper
       payment_status: overrides[:payment_status] || "paid",
       customer_details: {
         email: customer_email,
-        name: customer_name,
-        address: address_hash
+        name: billing_name,
+        address: billing_address_hash
       },
       collected_information: {
         shipping_details: {


### PR DESCRIPTION
## Problem

On the on-site checkout (behind the `ONSITE_CHECKOUT` flag), unticking "Billing is same as shipping information" in the Stripe Payment Element only showed a country dropdown. Stripe's default `billing_address_collection` (`"auto"`) collects only the fields a card payment needs, so the full billing form never appeared.

## What this does

- **Collect**: `Checkout::SessionBuilder` now sends `billing_address_collection: "required"` in the shared session params, so both the hosted page and the custom-mode Payment Element collect a full billing address. Verified end-to-end against the Stripe sandbox (session echoes `billing_address_collection=required`).
- **Persist**: additive migration adds six nullable `billing_*` columns to `orders` (no backfill, no validations). `Checkout::SessionDetails.billing_address` reads the completed session's `customer_details` (name + address) and fails open to `{}`; a missing billing address (historical orders, Link/wallet reuse, zero-total sessions) never blocks order creation. Both creation paths (success redirect via `OrderCreator` and the webhook fallback) write the same fields.
- **Display**: new `OrderAddress` service (mirroring `OrderSummary`) is the single source of address display lines for all five surfaces: order confirmation and order pages (shared `orders/_address` partial), admin order page, ops confirmation email (HTML "Bill to" + text `BILL TO`), and the PDF. Billing renders only when collected, and as a "Same as delivery address" note when it matches the delivery address. The comparison is address-only: Stripe fills `billing_name` from `customer_details.name` independently of the shipping recipient, so name equality would under-fire.
- **PDF layout**: the details section now measures its bounding-box height from the actual address lines (`pdf.height_of`), because content overflowing a fixed-height `bounding_box` makes Prawn break the entire layout onto a second page. Covered by a page-count regression test.

## Notes

- Historical orders have no billing data and render no billing block anywhere.
- The migration is purely additive and safe to deploy without a maintenance window.
- Hosted checkout (live today) gains one extra address section on the Stripe-hosted page.
- A code review ran over the branch; all five findings (PDF overflow, name-inclusive comparison, dead helper, two font-weight rule violations) are fixed in this diff.

## Testing

TDD throughout. Full suite: 3020 runs, 0 failures. Manual: worst-case PDF rendered visually (single page, both address blocks intact); sandbox Checkout Session created through the builder confirms the Stripe param in both ui modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)