### PR TITLE
Margot prospect research on new orders + bin/deploy fixes

### DIFF
--- a/app/jobs/margot_research_job.rb
+++ b/app/jobs/margot_research_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Asks Margot (our OpenClaw research agent) to research the customer behind
+# an order, but only for first-time customers - returning customers are
+# already known.
+#
+# Fire-and-forget: discards any error so a Margot problem never affects the
+# order flow. The notifier itself also swallows its own errors.
+class MargotResearchJob < ApplicationJob
+  queue_as :default
+  discard_on StandardError
+
+  def perform(order_id)
+    order = Order.includes(:order_items).find_by(id: order_id)
+    return unless order&.new_customer?
+
+    MargotNotifier.request_research(order)
+  end
+end

--- a/app/jobs/telegram_order_notification_job.rb
+++ b/app/jobs/telegram_order_notification_job.rb
@@ -13,5 +13,9 @@ class TelegramOrderNotificationJob < ApplicationJob
     return unless order
 
     TelegramNotifier.notify_new_order(order)
+
+    # Margot's research lands in the same group, so it rides the same
+    # trigger; the job itself skips returning customers.
+    MargotResearchJob.perform_later(order.id)
   end
 end

--- a/app/services/margot_notifier.rb
+++ b/app/services/margot_notifier.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "http"
+
+# Asks Margot (our OpenClaw research agent) to research a prospect by posting
+# an agent run to her Gateway webhook. Margot researches the customer and
+# delivers her findings to the Afida Telegram group herself, so this bypasses
+# Telegram's bot-to-bot delivery restrictions entirely.
+#
+# Fire-and-forget: this service never raises. Missing credentials, an outage,
+# or a network error is logged and swallowed so it can never break the order
+# flow. Callers should enqueue it via MargotResearchJob.
+#
+# Gateway webhook reference: https://docs.openclaw.ai/automation/cron-jobs#webhooks
+#
+# Credentials:
+#   margot:
+#     gateway_url: https://<margot-gateway-host>
+#     hook_token: <hooks.token from Margot's OpenClaw config>
+#
+class MargotNotifier
+  include ActionView::Helpers::NumberHelper
+
+  TIMEOUT_SECONDS = 10
+
+  class << self
+    # Asks Margot to research the order's customer.
+    # @param order [Order]
+    # @return [Boolean] true if the gateway accepted the run, false otherwise
+    def request_research(order)
+      new(order).deliver
+    end
+  end
+
+  def initialize(order)
+    @order = order
+  end
+
+  def deliver
+    unless credentials_configured?
+      log_error("credentials not configured")
+      return false
+    end
+
+    send_hook
+  rescue HTTP::Error, HTTP::TimeoutError => e
+    log_error("HTTP error: #{e.class} - #{e.message}")
+    false
+  rescue StandardError => e
+    log_error("Unexpected error: #{e.class} - #{e.message}")
+    false
+  end
+
+  private
+
+  def send_hook
+    response = HTTP
+      .timeout(TIMEOUT_SECONDS)
+      .auth("Bearer #{hook_token}")
+      .post("#{gateway_url}/hooks/agent", json: payload)
+
+    if response.status.success?
+      Rails.logger.info("[Margot] Research requested for order #{@order.display_number}")
+      true
+    else
+      log_error("Gateway returned #{response.status}: #{response.body}")
+      false
+    end
+  end
+
+  def payload
+    {
+      message: research_prompt,
+      name: "Research prospect #{@order.display_number}",
+      sessionMode: "isolated",
+      deliver: true,
+      channel: "telegram",
+      to: chat_id
+    }
+  end
+
+  def research_prompt
+    items = @order.order_items.map { |item| "#{item.quantity}x #{item.product_name}" }.join(", ")
+
+    <<~PROMPT
+      New first-time customer order #{@order.display_number} on afida.com. Research this prospect and post your findings to the group.
+
+      Customer: #{customer_name} (#{@order.email})
+      Shipping address: #{@order.full_shipping_address}
+      Order: #{items} - total #{number_to_currency(@order.total_amount, unit: "£")}
+    PROMPT
+  end
+
+  def customer_name
+    @order.shipping_name.presence || @order.email
+  end
+
+  def credentials_configured?
+    gateway_url.present? && hook_token.present? && chat_id.present?
+  end
+
+  def gateway_url
+    Rails.application.credentials.dig(:margot, :gateway_url)
+  end
+
+  def hook_token
+    Rails.application.credentials.dig(:margot, :hook_token)
+  end
+
+  # Margot posts her findings into the same group the order notification
+  # goes to.
+  def chat_id
+    Rails.application.credentials.dig(:telegram, :chat_id)
+  end
+
+  def log_error(message)
+    Rails.logger.error("[Margot] FAILED order='#{@order&.id}' error='#{message}'")
+  end
+end

--- a/app/services/telegram_notifier.rb
+++ b/app/services/telegram_notifier.rb
@@ -22,11 +22,11 @@ class TelegramNotifier
   MAX_ITEM_LINES = 25
 
   # Asks Margot (our research bot) to profile the buyer, only on a customer's
-  # first order — returning customers are already known. Telegram delivers a
-  # bot's message to another bot ONLY as a /command@TargetBot command mention
-  # (plain @mentions are not a delivery trigger), and only when at least one
-  # of the two bots has Bot-to-Bot Communication Mode enabled in @BotFather.
-  RESEARCH_MENTION = "/research@margot_afida_bot this prospect"
+  # first order — returning customers are already known. Telegram never
+  # delivers this bot's messages to Margot directly, so the notification
+  # carries a share button instead: tapping it lets a human post this mention
+  # into the group as themselves, which is the trigger Margot responds to.
+  RESEARCH_MENTION = "@margot_afida_bot research this prospect"
 
   class << self
     # Notifies the group chat that a new order has been placed.
@@ -73,12 +73,24 @@ class TelegramNotifier
   end
 
   def payload
-    {
+    payload = {
       chat_id: chat_id,
       text: build_message,
       parse_mode: "HTML",
       link_preview_options: { is_disabled: true }
     }
+    payload[:reply_markup] = research_button if @order.new_customer?
+    payload
+  end
+
+  def research_button
+    { inline_keyboard: [ [ { text: "🔍 Research prospect", url: research_share_url } ] ] }
+  end
+
+  # Opens Telegram's share dialog prefilled with the admin order link and the
+  # Margot mention; the human picks the group and the message posts as them.
+  def research_share_url
+    "https://t.me/share/url?url=#{ERB::Util.url_encode(admin_url)}&text=#{ERB::Util.url_encode(RESEARCH_MENTION)}"
   end
 
   def build_message
@@ -107,18 +119,15 @@ class TelegramNotifier
     lines << ""
     lines << "🔗 #{esc(admin_url)}"
 
-    return truncate_message(lines.join("\n")) unless @order.new_customer?
-
-    body = truncate_message(lines.join("\n"), limit: MAX_MESSAGE_LENGTH - RESEARCH_MENTION.length - 2)
-    "#{body}\n\n#{RESEARCH_MENTION}"
+    truncate_message(lines.join("\n"))
   end
 
   # Telegram rejects messages whose HTML doesn't parse, so a hard slice must
   # not leave a partial entity (e.g. "&amp;" cut to "&am") at the end.
-  def truncate_message(text, limit: MAX_MESSAGE_LENGTH)
-    return text if text.length <= limit
+  def truncate_message(text)
+    return text if text.length <= MAX_MESSAGE_LENGTH
 
-    text.first(limit).sub(/&[a-zA-Z#0-9]*\z/, "")
+    text.first(MAX_MESSAGE_LENGTH).sub(/&[a-zA-Z#0-9]*\z/, "")
   end
 
   def customer_name

--- a/app/services/telegram_notifier.rb
+++ b/app/services/telegram_notifier.rb
@@ -21,6 +21,13 @@ class TelegramNotifier
   MAX_MESSAGE_LENGTH = 4096
   MAX_ITEM_LINES = 25
 
+  # Asks Margot (our research bot) to profile the buyer, only on a customer's
+  # first order — returning customers are already known. For her to receive a
+  # message sent by this bot, both bots need Bot-to-Bot Communication Mode
+  # enabled in @BotFather, and Margot must be a group admin with Group Privacy
+  # Mode disabled (plain @mentions from bots are only delivered then).
+  RESEARCH_MENTION = "@margot_afida_bot research this prospect"
+
   class << self
     # Notifies the group chat that a new order has been placed.
     # @param order [Order]
@@ -83,6 +90,7 @@ class TelegramNotifier
     lines << "🛒 <b>New order #{esc(@order.display_number)}</b>"
     lines << ""
     lines << "👤 #{esc(customer_name)} (#{esc(@order.email)})"
+    lines << "📍 #{esc(@order.full_shipping_address)}"
     lines << "📦 #{line_items_count} line items / #{units_count} units · Total #{esc(formatted_total)}"
 
     if items.any?
@@ -99,15 +107,18 @@ class TelegramNotifier
     lines << ""
     lines << "🔗 #{esc(admin_url)}"
 
-    truncate_message(lines.join("\n"))
+    return truncate_message(lines.join("\n")) unless @order.new_customer?
+
+    body = truncate_message(lines.join("\n"), limit: MAX_MESSAGE_LENGTH - RESEARCH_MENTION.length - 2)
+    "#{body}\n\n#{RESEARCH_MENTION}"
   end
 
   # Telegram rejects messages whose HTML doesn't parse, so a hard slice must
   # not leave a partial entity (e.g. "&amp;" cut to "&am") at the end.
-  def truncate_message(text)
-    return text if text.length <= MAX_MESSAGE_LENGTH
+  def truncate_message(text, limit: MAX_MESSAGE_LENGTH)
+    return text if text.length <= limit
 
-    text.first(MAX_MESSAGE_LENGTH).sub(/&[a-zA-Z#0-9]*\z/, "")
+    text.first(limit).sub(/&[a-zA-Z#0-9]*\z/, "")
   end
 
   def customer_name

--- a/app/services/telegram_notifier.rb
+++ b/app/services/telegram_notifier.rb
@@ -22,11 +22,11 @@ class TelegramNotifier
   MAX_ITEM_LINES = 25
 
   # Asks Margot (our research bot) to profile the buyer, only on a customer's
-  # first order — returning customers are already known. For her to receive a
-  # message sent by this bot, both bots need Bot-to-Bot Communication Mode
-  # enabled in @BotFather, and Margot must be a group admin with Group Privacy
-  # Mode disabled (plain @mentions from bots are only delivered then).
-  RESEARCH_MENTION = "@margot_afida_bot research this prospect"
+  # first order — returning customers are already known. Telegram delivers a
+  # bot's message to another bot ONLY as a /command@TargetBot command mention
+  # (plain @mentions are not a delivery trigger), and only when at least one
+  # of the two bots has Bot-to-Bot Communication Mode enabled in @BotFather.
+  RESEARCH_MENTION = "/research@margot_afida_bot this prospect"
 
   class << self
     # Notifies the group chat that a new order has been placed.

--- a/app/services/telegram_notifier.rb
+++ b/app/services/telegram_notifier.rb
@@ -23,9 +23,10 @@ class TelegramNotifier
 
   # Asks Margot (our research bot) to profile the buyer, only on a customer's
   # first order — returning customers are already known. Telegram never
-  # delivers this bot's messages to Margot directly, so the notification
-  # carries a share button instead: tapping it lets a human post this mention
-  # into the group as themselves, which is the trigger Margot responds to.
+  # delivers this bot's messages to Margot directly (and a button cannot post
+  # as the user), so the notification carries a copy-text button: tapping it
+  # copies this mention for the human to paste and send in the group, which
+  # is the trigger Margot responds to.
   RESEARCH_MENTION = "@margot_afida_bot research this prospect"
 
   class << self
@@ -84,13 +85,7 @@ class TelegramNotifier
   end
 
   def research_button
-    { inline_keyboard: [ [ { text: "🔍 Research prospect", url: research_share_url } ] ] }
-  end
-
-  # Opens Telegram's share dialog prefilled with the admin order link and the
-  # Margot mention; the human picks the group and the message posts as them.
-  def research_share_url
-    "https://t.me/share/url?url=#{ERB::Util.url_encode(admin_url)}&text=#{ERB::Util.url_encode(RESEARCH_MENTION)}"
+    { inline_keyboard: [ [ { text: "🔍 Margot, research the client", copy_text: { text: RESEARCH_MENTION } } ] ] }
   end
 
   def build_message

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy via Kamal with the server SSH key loaded from 1Password.
+#
+# The key is piped from 1Password straight into the ssh-agent, so it never
+# touches disk. Run from a terminal: `op` prompts for your 1Password
+# password if the shell has no active session.
+#
+# Requires: op (1Password CLI) signed in to the account holding the key,
+# and an ssh-agent (`eval $(ssh-agent)` if none is running).
+#
+# Usage: bin/deploy [kamal deploy args, e.g. --roles=web]
+
+# 1Password secret reference for the deploy key. Override with:
+#   OP_SSH_KEY_REF="op://<vault>/<item>/private key" bin/deploy
+OP_SSH_KEY_REF="${OP_SSH_KEY_REF:-op://Private/afida deploy/private key}"
+
+if ! command -v op >/dev/null; then
+  echo "1Password CLI (op) not found on PATH" >&2
+  exit 1
+fi
+
+if ! ssh-add -l >/dev/null 2>&1; then
+  case $? in
+    1) ;; # agent running, no keys yet: fine
+    *) echo "No ssh-agent reachable; start one with: eval \$(ssh-agent)" >&2; exit 1 ;;
+  esac
+fi
+
+# Read the key once (op may prompt), keep it in memory only.
+key_material="$(op read "${OP_SSH_KEY_REF}?ssh-format=openssh")"
+fingerprint="$(printf '%s\n' "$key_material" | ssh-keygen -lf /dev/stdin | awk '{print $2}')"
+
+# Only load the key when the agent doesn't hold it already, so repeat
+# deploys in one session don't churn the agent.
+if ! ssh-add -l 2>/dev/null | grep -q "$fingerprint"; then
+  printf '%s\n' "$key_material" | ssh-add -
+fi
+unset key_material
+
+exec kamal deploy "$@"

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,47 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deploy via Kamal with the server SSH key loaded from 1Password.
-#
-# The key is piped from 1Password straight into the ssh-agent, so it never
-# touches disk. Run from a terminal: `op` prompts for your 1Password
-# password if the shell has no active session.
-#
-# Requires: op (1Password CLI) signed in to the account holding the key,
-# and an ssh-agent (`eval $(ssh-agent)` if none is running).
+# Deploy via Kamal with the server SSH key loaded from 1Password
+# (see bin/load-deploy-key).
 #
 # Usage: bin/deploy [kamal deploy args; defaults to --roles=web]
 
-# 1Password secret reference for the deploy key. Override with:
-#   OP_SSH_KEY_REF="op://<vault>/<item>/private key" bin/deploy
-OP_SSH_KEY_REF="${OP_SSH_KEY_REF:-op://Private/afida/private key}"
-
-if ! command -v op >/dev/null; then
-  echo "1Password CLI (op) not found on PATH" >&2
-  exit 1
-fi
-
-# ssh-add -l exits 1 for "agent running, no keys yet" (fine) and 2 for "no
-# agent reachable". Capture the status directly: inside `if ! ...`, $? holds
-# the negated pipeline's status, not ssh-add's.
-agent_status=0
-ssh-add -l >/dev/null 2>&1 || agent_status=$?
-if [ "$agent_status" -gt 1 ]; then
-  echo "No ssh-agent reachable; start one with: eval \$(ssh-agent)" >&2
-  exit 1
-fi
-
-# op read does not prompt for a sign-in itself; without a session it fails
-# with "You are not currently signed in". Sign in here (prompts on the tty)
-# so the session covers the read below.
-if ! op whoami >/dev/null 2>&1; then
-  eval "$(op signin)" || { echo "1Password sign-in failed" >&2; exit 1; }
-fi
-
-# Pipe the key from 1Password straight into the agent; it never touches
-# disk. Re-adding a key the agent already holds is a no-op, so repeat
-# deploys in one session are fine without any fingerprint bookkeeping.
-op read "${OP_SSH_KEY_REF}?ssh-format=openssh" | ssh-add -
+"$(dirname "$0")/load-deploy-key"
 
 # Default to --roles=web: plain `kamal deploy` aborts on the postgres
 # accessory host before retagging :latest and silently keeps serving the old

--- a/bin/deploy
+++ b/bin/deploy
@@ -10,33 +10,44 @@ set -euo pipefail
 # Requires: op (1Password CLI) signed in to the account holding the key,
 # and an ssh-agent (`eval $(ssh-agent)` if none is running).
 #
-# Usage: bin/deploy [kamal deploy args, e.g. --roles=web]
+# Usage: bin/deploy [kamal deploy args; defaults to --roles=web]
 
 # 1Password secret reference for the deploy key. Override with:
 #   OP_SSH_KEY_REF="op://<vault>/<item>/private key" bin/deploy
-OP_SSH_KEY_REF="${OP_SSH_KEY_REF:-op://Private/afida deploy/private key}"
+OP_SSH_KEY_REF="${OP_SSH_KEY_REF:-op://Private/afida/private key}"
 
 if ! command -v op >/dev/null; then
   echo "1Password CLI (op) not found on PATH" >&2
   exit 1
 fi
 
-if ! ssh-add -l >/dev/null 2>&1; then
-  case $? in
-    1) ;; # agent running, no keys yet: fine
-    *) echo "No ssh-agent reachable; start one with: eval \$(ssh-agent)" >&2; exit 1 ;;
-  esac
+# ssh-add -l exits 1 for "agent running, no keys yet" (fine) and 2 for "no
+# agent reachable". Capture the status directly: inside `if ! ...`, $? holds
+# the negated pipeline's status, not ssh-add's.
+agent_status=0
+ssh-add -l >/dev/null 2>&1 || agent_status=$?
+if [ "$agent_status" -gt 1 ]; then
+  echo "No ssh-agent reachable; start one with: eval \$(ssh-agent)" >&2
+  exit 1
 fi
 
-# Read the key once (op may prompt), keep it in memory only.
-key_material="$(op read "${OP_SSH_KEY_REF}?ssh-format=openssh")"
-fingerprint="$(printf '%s\n' "$key_material" | ssh-keygen -lf /dev/stdin | awk '{print $2}')"
-
-# Only load the key when the agent doesn't hold it already, so repeat
-# deploys in one session don't churn the agent.
-if ! ssh-add -l 2>/dev/null | grep -q "$fingerprint"; then
-  printf '%s\n' "$key_material" | ssh-add -
+# op read does not prompt for a sign-in itself; without a session it fails
+# with "You are not currently signed in". Sign in here (prompts on the tty)
+# so the session covers the read below.
+if ! op whoami >/dev/null 2>&1; then
+  eval "$(op signin)" || { echo "1Password sign-in failed" >&2; exit 1; }
 fi
-unset key_material
 
-exec kamal deploy "$@"
+# Pipe the key from 1Password straight into the agent; it never touches
+# disk. Re-adding a key the agent already holds is a no-op, so repeat
+# deploys in one session are fine without any fingerprint bookkeeping.
+op read "${OP_SSH_KEY_REF}?ssh-format=openssh" | ssh-add -
+
+# Default to --roles=web: plain `kamal deploy` aborts on the postgres
+# accessory host before retagging :latest and silently keeps serving the old
+# image (see docs/runbooks/deploying.md).
+if [ "$#" -eq 0 ]; then
+  set -- --roles=web
+fi
+
+exec "$(dirname "$0")/kamal" deploy "$@"

--- a/bin/load-deploy-key
+++ b/bin/load-deploy-key
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load the Hetzner deploy SSH key from 1Password into the running ssh-agent,
+# so kamal commands (deploy, console, logs, shell...) can authenticate.
+# The key is piped straight into the agent and never touches disk.
+# bin/deploy runs this automatically; run it yourself before other kamal
+# commands in a fresh shell, e.g.: bin/load-deploy-key && bin/kamal console
+#
+# 1Password secret reference for the deploy key. Override with:
+#   OP_SSH_KEY_REF="op://<vault>/<item>/private key" bin/load-deploy-key
+OP_SSH_KEY_REF="${OP_SSH_KEY_REF:-op://Private/afida/private key}"
+
+if ! command -v op >/dev/null; then
+  echo "1Password CLI (op) not found on PATH" >&2
+  exit 1
+fi
+
+# ssh-add -l exits 1 for "agent running, no keys yet" (fine) and 2 for "no
+# agent reachable". Capture the status directly: inside `if ! ...`, $? holds
+# the negated pipeline's status, not ssh-add's.
+agent_status=0
+ssh-add -l >/dev/null 2>&1 || agent_status=$?
+if [ "$agent_status" -gt 1 ]; then
+  echo "No ssh-agent reachable; start one with: eval \$(ssh-agent)" >&2
+  exit 1
+fi
+
+# op read does not prompt for a sign-in itself; without a session it fails
+# with "You are not currently signed in". Sign in here (prompts on the tty)
+# so the session covers the read below.
+if ! op whoami >/dev/null 2>&1; then
+  eval "$(op signin)" || { echo "1Password sign-in failed" >&2; exit 1; }
+fi
+
+# Re-adding a key the agent already holds is a no-op, so repeat runs in one
+# session are fine without any fingerprint bookkeeping.
+op read "${OP_SSH_KEY_REF}?ssh-format=openssh" | ssh-add -

--- a/test/jobs/margot_research_job_test.rb
+++ b/test/jobs/margot_research_job_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MargotResearchJobTest < ActiveJob::TestCase
+  setup do
+    @order = orders(:one)
+  end
+
+  test "requests research for a new customer's order" do
+    @order.update_columns(user_id: nil, email: "first-order@example.com")
+    MargotNotifier.expects(:request_research).with { |order| order.id == @order.id }
+
+    MargotResearchJob.perform_now(@order.id)
+  end
+
+  test "does not request research for a returning customer" do
+    assert_not @order.new_customer?, "fixture should be a returning customer"
+    MargotNotifier.expects(:request_research).never
+
+    MargotResearchJob.perform_now(@order.id)
+  end
+
+  test "does nothing when the order does not exist" do
+    MargotNotifier.expects(:request_research).never
+
+    MargotResearchJob.perform_now(-1)
+  end
+end

--- a/test/jobs/telegram_order_notification_job_test.rb
+++ b/test/jobs/telegram_order_notification_job_test.rb
@@ -13,6 +13,14 @@ class TelegramOrderNotificationJobTest < ActiveJob::TestCase
     TelegramOrderNotificationJob.perform_now(@order.id)
   end
 
+  test "enqueues a Margot research request for the order" do
+    TelegramNotifier.stubs(:notify_new_order)
+
+    assert_enqueued_with(job: MargotResearchJob, args: [ @order.id ]) do
+      TelegramOrderNotificationJob.perform_now(@order.id)
+    end
+  end
+
   test "does nothing when the order no longer exists" do
     TelegramNotifier.expects(:notify_new_order).never
 

--- a/test/services/margot_notifier_test.rb
+++ b/test/services/margot_notifier_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+
+class MargotNotifierTest < ActiveSupport::TestCase
+  GATEWAY_URL = "https://margot.example.com"
+  HOOK_TOKEN = "test_hook_token"
+  CHAT_ID = "-1001234567890"
+  HOOK_ENDPOINT = "#{GATEWAY_URL}/hooks/agent"
+
+  setup do
+    @order = orders(:one)
+    stub_margot_credentials
+  end
+
+  test "posts an agent hook request and returns true on success" do
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 200, body: { ok: true, runId: "r1" }.to_json)
+
+    assert MargotNotifier.request_research(@order)
+    assert_requested :post, HOOK_ENDPOINT
+  end
+
+  test "authenticates with the hook token as a bearer token" do
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 200, body: { ok: true }.to_json)
+
+    MargotNotifier.request_research(@order)
+
+    assert_requested :post, HOOK_ENDPOINT, headers: { "Authorization" => "Bearer #{HOOK_TOKEN}" }
+  end
+
+  test "targets the Telegram group and requests delivery" do
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 200, body: { ok: true }.to_json)
+
+    MargotNotifier.request_research(@order)
+
+    assert_requested :post, HOOK_ENDPOINT do |req|
+      body = JSON.parse(req.body)
+      body["channel"] == "telegram" && body["to"] == CHAT_ID && body["deliver"] == true
+    end
+  end
+
+  test "prompt includes the order details Margot needs" do
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 200, body: { ok: true }.to_json)
+
+    MargotNotifier.request_research(@order)
+
+    assert_requested :post, HOOK_ENDPOINT do |req|
+      message = JSON.parse(req.body)["message"]
+      message.include?(@order.display_number) &&
+        message.include?(@order.email) &&
+        message.include?(@order.shipping_name) &&
+        message.include?(@order.full_shipping_address)
+    end
+  end
+
+  test "returns false and sends nothing when credentials are missing" do
+    stub_margot_credentials(gateway_url: nil, hook_token: nil)
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 200, body: { ok: true }.to_json)
+
+    assert_not MargotNotifier.request_research(@order)
+    assert_not_requested :post, HOOK_ENDPOINT
+  end
+
+  test "returns false on an API error response" do
+    stub_request(:post, HOOK_ENDPOINT).to_return(status: 401, body: { ok: false }.to_json)
+
+    assert_not MargotNotifier.request_research(@order)
+  end
+
+  test "returns false and does not raise on timeout" do
+    stub_request(:post, HOOK_ENDPOINT).to_timeout
+
+    assert_nothing_raised do
+      assert_not MargotNotifier.request_research(@order)
+    end
+  end
+
+  test "returns false and does not raise on a network error" do
+    stub_request(:post, HOOK_ENDPOINT).to_raise(HTTP::ConnectionError.new("Connection refused"))
+
+    assert_nothing_raised do
+      assert_not MargotNotifier.request_research(@order)
+    end
+  end
+
+  private
+
+  def stub_margot_credentials(gateway_url: GATEWAY_URL, hook_token: HOOK_TOKEN, chat_id: CHAT_ID)
+    MargotNotifier.any_instance.stubs(:gateway_url).returns(gateway_url)
+    MargotNotifier.any_instance.stubs(:hook_token).returns(hook_token)
+    MargotNotifier.any_instance.stubs(:chat_id).returns(chat_id)
+  end
+end

--- a/test/services/telegram_notifier_test.rb
+++ b/test/services/telegram_notifier_test.rb
@@ -187,9 +187,7 @@ class TelegramNotifierTest < ActiveSupport::TestCase
     assert_requested :post, TELEGRAM_ENDPOINT do |req|
       button = JSON.parse(req.body).dig("reply_markup", "inline_keyboard", 0, 0)
       button.present? &&
-        button["url"].start_with?("https://t.me/share/url?") &&
-        CGI.unescape(button["url"]).include?(TelegramNotifier::RESEARCH_MENTION) &&
-        CGI.unescape(button["url"]).include?("/admin/orders/#{@order.id}")
+        button.dig("copy_text", "text") == TelegramNotifier::RESEARCH_MENTION
     end
   end
 

--- a/test/services/telegram_notifier_test.rb
+++ b/test/services/telegram_notifier_test.rb
@@ -178,40 +178,30 @@ class TelegramNotifierTest < ActiveSupport::TestCase
     end
   end
 
-  test "tags Margot to research the prospect on a new customer's order" do
+  test "adds a research button on a new customer's order" do
     stub_telegram_send_message
     make_new_customer!(@order)
 
     TelegramNotifier.notify_new_order(@order)
 
     assert_requested :post, TELEGRAM_ENDPOINT do |req|
-      JSON.parse(req.body)["text"].end_with?(TelegramNotifier::RESEARCH_MENTION)
+      button = JSON.parse(req.body).dig("reply_markup", "inline_keyboard", 0, 0)
+      button.present? &&
+        button["url"].start_with?("https://t.me/share/url?") &&
+        CGI.unescape(button["url"]).include?(TelegramNotifier::RESEARCH_MENTION) &&
+        CGI.unescape(button["url"]).include?("/admin/orders/#{@order.id}")
     end
   end
 
-  test "does not tag Margot when the customer has ordered before" do
+  test "no research button when the customer has ordered before" do
     stub_telegram_send_message
     assert_not @order.new_customer?, "fixture should be a returning customer"
 
     TelegramNotifier.notify_new_order(@order)
 
     assert_requested :post, TELEGRAM_ENDPOINT do |req|
-      !JSON.parse(req.body)["text"].include?("@margot_afida_bot")
-    end
-  end
-
-  test "truncation never cuts off the Margot mention" do
-    stub_telegram_send_message
-    make_new_customer!(@order)
-    item = @order.order_items.first
-    item.update!(product_name: "X" * 5000)
-
-    TelegramNotifier.notify_new_order(@order)
-
-    assert_requested :post, TELEGRAM_ENDPOINT do |req|
-      text = JSON.parse(req.body)["text"]
-      text.length <= TelegramNotifier::MAX_MESSAGE_LENGTH &&
-        text.end_with?(TelegramNotifier::RESEARCH_MENTION)
+      body = JSON.parse(req.body)
+      !body.key?("reply_markup") && !body["text"].include?("margot")
     end
   end
 

--- a/test/services/telegram_notifier_test.rb
+++ b/test/services/telegram_notifier_test.rb
@@ -168,6 +168,53 @@ class TelegramNotifierTest < ActiveSupport::TestCase
     assert_telegram_message_sent
   end
 
+  test "message includes the shipping address" do
+    stub_telegram_send_message
+
+    TelegramNotifier.notify_new_order(@order)
+
+    assert_requested :post, TELEGRAM_ENDPOINT do |req|
+      JSON.parse(req.body)["text"].include?(@order.full_shipping_address)
+    end
+  end
+
+  test "tags Margot to research the prospect on a new customer's order" do
+    stub_telegram_send_message
+    make_new_customer!(@order)
+
+    TelegramNotifier.notify_new_order(@order)
+
+    assert_requested :post, TELEGRAM_ENDPOINT do |req|
+      JSON.parse(req.body)["text"].end_with?(TelegramNotifier::RESEARCH_MENTION)
+    end
+  end
+
+  test "does not tag Margot when the customer has ordered before" do
+    stub_telegram_send_message
+    assert_not @order.new_customer?, "fixture should be a returning customer"
+
+    TelegramNotifier.notify_new_order(@order)
+
+    assert_requested :post, TELEGRAM_ENDPOINT do |req|
+      !JSON.parse(req.body)["text"].include?("@margot_afida_bot")
+    end
+  end
+
+  test "truncation never cuts off the Margot mention" do
+    stub_telegram_send_message
+    make_new_customer!(@order)
+    item = @order.order_items.first
+    item.update!(product_name: "X" * 5000)
+
+    TelegramNotifier.notify_new_order(@order)
+
+    assert_requested :post, TELEGRAM_ENDPOINT do |req|
+      text = JSON.parse(req.body)["text"]
+      text.length <= TelegramNotifier::MAX_MESSAGE_LENGTH &&
+        text.end_with?(TelegramNotifier::RESEARCH_MENTION)
+    end
+  end
+
   test "falls back to email when shipping name is blank" do
     stub_telegram_send_message
     @order.update_columns(shipping_name: "")
@@ -177,5 +224,13 @@ class TelegramNotifierTest < ActiveSupport::TestCase
     assert_requested :post, TELEGRAM_ENDPOINT do |req|
       JSON.parse(req.body)["text"].include?(@order.email)
     end
+  end
+
+  private
+
+  # Detaches the order from its user and gives it an email no other order
+  # uses, so Order#new_customer? sees a first-time buyer.
+  def make_new_customer!(order)
+    order.update_columns(user_id: nil, email: "first-order@example.com")
   end
 end


### PR DESCRIPTION
## Summary

Two threads of work that evolved together in one session:

### Margot prospect research
- New-customer order notifications now trigger automatic prospect research by Margot (our OpenClaw agent): `MargotResearchJob` (enqueued from `TelegramOrderNotificationJob`) POSTs an agent run to her Gateway webhook (`/hooks/agent`) with the order details, and she posts her findings to the Afida Orders Telegram group herself. Returning customers are skipped (`Order#new_customer?`).
- The Telegram notification gains a shipping-address line and, for new customers, a "Margot, research the client" copy-text button as a manual fallback.
- The earlier in-message approaches (plain @mention, `/research@bot` command mention) are in the history: Telegram does not deliver a bot's messages to another bot, which is why the webhook architecture won.
- Requires `margot.gateway_url` / `margot.hook_token` credentials (already added to production).

### bin/deploy fixes
- Fixed the unreachable "agent running, no keys yet" branch (`$?` after `if !` is always 0).
- Signs into 1Password when there is no session; corrected the item reference; pipes the key straight into ssh-add (the fingerprint pre-check broke on stdin).
- Defaults to `--roles=web` (plain `kamal deploy` silently ships nothing, per docs/runbooks/deploying.md) and execs the `bin/kamal` binstub.
- Key loading extracted to `bin/load-deploy-key` so other kamal commands (console, logs) work in a fresh shell.

## Test plan
- Full suite green (3317 runs, 0 failures).
- Verified live in production: deploy, Telegram notification with button, and Margot's gateway webhook smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)